### PR TITLE
feature/37

### DIFF
--- a/LotCoMClient/Models/Datasources/DataRecord.cs
+++ b/LotCoMClient/Models/Datasources/DataRecord.cs
@@ -53,6 +53,10 @@ public partial class DataRecord : ObservableObject
     public partial bool IncludesModelNumber {get; set;} = false;
     [ObservableProperty]
     public partial bool IncludesHeatNumber {get; set;} = false;
+    [ObservableProperty]
+    public partial bool IncludesScanAddress {get; set;} = false;
+    [ObservableProperty]
+    public partial bool IncludesProductionDate {get; set;} = false;
 
     /// <summary>
     /// Creates a new DataRecord object.
@@ -100,6 +104,8 @@ public partial class DataRecord : ObservableObject
         IncludesDieNumber = Requirements.Contains("DieNumber");
         IncludesDieNumber = Requirements.Contains("ModelNumber");
         IncludesHeatNumber = Requirements.Contains("HeatNumber");
+        IncludesScanAddress = ScanAddress is not null;
+        IncludesProductionDate = ProductionDate is not null;
     }
 
     /// <summary>
@@ -111,11 +117,11 @@ public partial class DataRecord : ObservableObject
         // add required Process name
         string CSVLine = $"{RecordProcess.FullName}";
         // add ScanRecord specific data fields
-        if (ProductionDate is not null)
+        if (IncludesProductionDate)
         {
             CSVLine = $"{CSVLine},{RecordDate}-{RecordTime}";
         }
-        if (ScanAddress is not null)
+        if (IncludesScanAddress)
         {
             CSVLine = $"{CSVLine},{ScanAddress}";
         }
@@ -147,7 +153,7 @@ public partial class DataRecord : ObservableObject
             CSVLine = $"{CSVLine},{HeatNumber}";
         }
         // add the back set of universal data
-        if (ProductionDate is not null)
+        if (IncludesProductionDate)
         {
             CSVLine = $"{CSVLine},{ProductionDate}-{ProductionTime}";
         }

--- a/LotCoMClient/Models/Datasources/DataRecord.cs
+++ b/LotCoMClient/Models/Datasources/DataRecord.cs
@@ -10,6 +10,10 @@ public partial class DataRecord : ObservableObject
     [ObservableProperty]
     public partial string? ScanAddress {get; set;}
     [ObservableProperty]
+    public partial string? ProductionDate {get; set;}
+    [ObservableProperty]
+    public partial string? ProductionTime {get; set;}
+    [ObservableProperty]
     public partial Process RecordProcess {get; set;}
     [ObservableProperty]
     public partial Part RecordPart {get; set;}
@@ -67,7 +71,9 @@ public partial class DataRecord : ObservableObject
     /// <param name="RecordShift">The Shift Number assigned to this record.</param>
     /// <param name="OperatorID">The Operator ID assigned to this record.</param>
     /// <param name="ScanAddress">(Optional) the IP Address of the Scanner producing this record. Only applicable to ScanRecords.</param>
-    public DataRecord(Process RecordProcess, Part RecordPart, string Quantity, string JBKNumber, string LotNumber, string DeburrJBKNumber, string DieNumber, string ModelNumber, string HeatNumber, string RecordDate, string RecordTime, string RecordShift, string OperatorID, string? ScanAddress = null) 
+    /// <param name="ProductionDate">(Optional) the Production Date of the Record's Label. Only applicable to ScanRecords.</param>
+    /// <param name="ProductionTime">(Optional) the Production Time of the Record's Label. Only applicable to ScanRecords.</param>
+    public DataRecord(Process RecordProcess, Part RecordPart, string Quantity, string JBKNumber, string LotNumber, string DeburrJBKNumber, string DieNumber, string ModelNumber, string HeatNumber, string RecordDate, string RecordTime, string RecordShift, string OperatorID, string? ScanAddress = null, string? ProductionDate = null, string? ProductionTime = null) 
     {
         // set the Record's properties
         this.RecordProcess = RecordProcess;
@@ -84,6 +90,8 @@ public partial class DataRecord : ObservableObject
         this.RecordShift = RecordShift;
         this.OperatorID = OperatorID;
         this.ScanAddress = ScanAddress;
+        this.ProductionDate = ProductionDate;
+        this.ProductionTime = ProductionTime;
         // configure the Includes flags using the RecordProcess' requirements
         List<string> Requirements = RecordProcess.RequiredFields;
         IncludesJBKNumber = Requirements.Contains("JBKNumber");
@@ -101,7 +109,7 @@ public partial class DataRecord : ObservableObject
     public string ToCSV() 
     {
         // add the front set of universal data
-        string CSVLine = $"{RecordProcess.FullName},{RecordPart.PartNumber},{RecordPart.PartName},{Quantity}";
+        string CSVLine = $"{RecordProcess.FullName},{RecordDate}-{RecordTime},{ScanAddress},{RecordPart.PartNumber},{RecordPart.PartName},{Quantity}";
         // add the variably-required data fields to the Line
         if (IncludesJBKNumber) 
         {
@@ -128,7 +136,7 @@ public partial class DataRecord : ObservableObject
             CSVLine = $"{CSVLine},{HeatNumber}";
         }
         // add the back set of universal data
-        CSVLine = $"{CSVLine},{RecordDate}-{RecordTime},{RecordShift},{OperatorID}";
+        CSVLine = $"{CSVLine},{ProductionDate}-{ProductionTime},{RecordShift},{OperatorID}";
         return CSVLine;
     }
 }

--- a/LotCoMClient/Models/Datasources/DataRecord.cs
+++ b/LotCoMClient/Models/Datasources/DataRecord.cs
@@ -108,8 +108,19 @@ public partial class DataRecord : ObservableObject
     /// <returns></returns>
     public string ToCSV() 
     {
-        // add the front set of universal data
-        string CSVLine = $"{RecordProcess.FullName},{RecordDate}-{RecordTime},{ScanAddress},{RecordPart.PartNumber},{RecordPart.PartName},{Quantity}";
+        // add required Process name
+        string CSVLine = $"{RecordProcess.FullName}";
+        // add ScanRecord specific data fields
+        if (ProductionDate is not null)
+        {
+            CSVLine = $"{CSVLine},{RecordDate}-{RecordTime}";
+        }
+        if (ScanAddress is not null)
+        {
+            CSVLine = $"{CSVLine},{ScanAddress}";
+        }
+        // add universal required fields
+        CSVLine = $"{CSVLine},{RecordPart.PartNumber},{RecordPart.PartName},{Quantity}";
         // add the variably-required data fields to the Line
         if (IncludesJBKNumber) 
         {
@@ -136,7 +147,15 @@ public partial class DataRecord : ObservableObject
             CSVLine = $"{CSVLine},{HeatNumber}";
         }
         // add the back set of universal data
-        CSVLine = $"{CSVLine},{ProductionDate}-{ProductionTime},{RecordShift},{OperatorID}";
+        if (ProductionDate is not null)
+        {
+            CSVLine = $"{CSVLine},{ProductionDate}-{ProductionTime}";
+        }
+        else
+        {
+            CSVLine = $"{CSVLine},{RecordDate}-{RecordTime}";
+        }
+        CSVLine = $"{CSVLine},{RecordShift},{OperatorID}";
         return CSVLine;
     }
 }

--- a/LotCoMClient/Models/Datasources/DataRecord.cs
+++ b/LotCoMClient/Models/Datasources/DataRecord.cs
@@ -58,6 +58,14 @@ public partial class DataRecord : ObservableObject
     [ObservableProperty]
     public partial bool IncludesProductionDate {get; set;} = false;
 
+    // these flags control the different display mode for ScanRecords
+    [ObservableProperty]
+    public partial bool IsScanRecord {get; set;}
+    [ObservableProperty]
+    public partial bool IsNotScanRecord {get; set;}
+    [ObservableProperty]
+    public partial string? ProductionTimestamp {get; set;}
+
     /// <summary>
     /// Creates a new DataRecord object.
     /// </summary>
@@ -106,6 +114,12 @@ public partial class DataRecord : ObservableObject
         IncludesHeatNumber = Requirements.Contains("HeatNumber");
         IncludesScanAddress = ScanAddress is not null;
         IncludesProductionDate = ProductionDate is not null;
+        // configure ScanRecord flags
+        IsScanRecord = IncludesScanAddress && IncludesProductionDate;
+        if (IsScanRecord)
+        {
+            ProductionTimestamp = $"{ProductionDate}-{ProductionTime}";
+        }
     }
 
     /// <summary>
@@ -117,11 +131,11 @@ public partial class DataRecord : ObservableObject
         // add required Process name
         string CSVLine = $"{RecordProcess.FullName}";
         // add ScanRecord specific data fields
-        if (IncludesProductionDate)
+        if (IsScanRecord)
         {
             CSVLine = $"{CSVLine},{RecordDate}-{RecordTime}";
         }
-        if (IncludesScanAddress)
+        if (IsScanRecord)
         {
             CSVLine = $"{CSVLine},{ScanAddress}";
         }
@@ -153,7 +167,7 @@ public partial class DataRecord : ObservableObject
             CSVLine = $"{CSVLine},{HeatNumber}";
         }
         // add the back set of universal data
-        if (IncludesProductionDate)
+        if (IsScanRecord)
         {
             CSVLine = $"{CSVLine},{ProductionDate}-{ProductionTime}";
         }

--- a/LotCoMClient/Models/Datasources/DataRecord.cs
+++ b/LotCoMClient/Models/Datasources/DataRecord.cs
@@ -101,7 +101,7 @@ public partial class DataRecord : ObservableObject
     public string ToCSV() 
     {
         // add the front set of universal data
-        string CSVLine = $",{RecordProcess.FullName},{RecordPart.PartNumber},{RecordPart.PartName},{Quantity}";
+        string CSVLine = $"{RecordProcess.FullName},{RecordPart.PartNumber},{RecordPart.PartName},{Quantity}";
         // add the variably-required data fields to the Line
         if (IncludesJBKNumber) 
         {
@@ -128,7 +128,7 @@ public partial class DataRecord : ObservableObject
             CSVLine = $"{CSVLine},{HeatNumber}";
         }
         // add the back set of universal data
-        CSVLine = $"{CSVLine},{RecordDate},{RecordTime},{RecordShift},{OperatorID}";
+        CSVLine = $"{CSVLine},{RecordDate}-{RecordTime},{RecordShift},{OperatorID}";
         return CSVLine;
     }
 }

--- a/LotCoMClient/Models/Datasources/DataTable.cs
+++ b/LotCoMClient/Models/Datasources/DataTable.cs
@@ -80,13 +80,13 @@ public partial class DataTable : ObservableObject
     public PageSet ActivePageSet
     {
         get {return _activePageSet;}
-        private set {_activePageSet = value;}
+        private set 
+        {
+            _activePageSet = value;
+            OnPropertyChanged(nameof(_activePageSet));
+            OnPropertyChanged(nameof(ActivePageSet));
+        }
     }
-
-    /// <summary>
-    /// Returns the total count of Records in the Data Table file (as of the last ReadLines call).
-    /// </summary>
-    public int RecordCount => LastReadLines.Count;
 
     /// <summary>
     /// Parses a DataRecord of the DataTable's RecordType from CSVLine.
@@ -416,7 +416,7 @@ public partial class DataTable : ObservableObject
     public async Task<Page> RequestPage(int PageNumber, int PageLength, int MaxCount = -1) 
     {
         // confirm that Pages is set to provide Pages of the correct size
-        if (ActivePageSet.Count < 1 || ActivePageSet.Pages[0].MaxLength != PageLength)
+        if (ActivePageSet.PageCount < 1 || ActivePageSet.Pages[0].MaxLength != PageLength)
         {
             await RefreshPages(MaxCount, PageLength);
         }

--- a/LotCoMClient/Models/Datasources/DataTable.cs
+++ b/LotCoMClient/Models/Datasources/DataTable.cs
@@ -101,6 +101,28 @@ public partial class DataTable : ObservableObject
     /// </summary>
     /// <param name="Text"></param>
     /// <returns>A List of strings.</returns>
+    private List<string> ParseLines(string Text) {
+        // separate the read text into record lines (split by newline character)
+        List<string> RecordLines = Text
+            .Split("\n")
+            .ToList();
+        // remove the first entry and save it as the headers property
+        Headers = RecordLines[0]
+            .Split(",")
+            .ToList();
+        RecordLines.RemoveAt(0);
+        // remove any empty lines
+        RecordLines = RecordLines
+            .Where(x => !x.Equals(""))
+            .ToList();
+        return RecordLines;
+    }
+
+    /// <summary>
+    /// Asynchronously parses a bulk string into Lines that can be parsed.
+    /// </summary>
+    /// <param name="Text"></param>
+    /// <returns>A List of strings.</returns>
     private async Task<List<string>> ParseLinesAsync(string Text) {
         return await Task.Run(() => {
             // separate the read text into record lines (split by newline character)
@@ -122,6 +144,33 @@ public partial class DataTable : ObservableObject
 
     /// <summary>
     /// Reads the data file and formats the text as a List of strings that can later be parsed into DataRecord objects.
+    /// Stores the List in Table.LastReadLines.
+    /// </summary>
+    /// <remarks>
+    /// Does not perform any formatting.
+    /// </remarks>
+    /// <returns>A List of Lines as strings.</returns>
+    private List<string> ReadLines()
+    {
+        // read the Database Table at the Path property
+        string Text;
+        try 
+        {
+            Text = File.ReadAllText(Path);
+        } 
+        catch (Exception _ex) 
+        {
+            throw new FileLoadException($"Failed to read the Database file: '{Path}' due to the following exception:\n{_ex.Message}.");
+        }
+        // split the text into a list of Line strings and update the cached Lines list
+        LastReadLines = ParseLines(Text);
+        // reverse list to show newest Lines first
+        LastReadLines.Reverse();
+        return LastReadLines;
+    }
+
+    /// <summary>
+    /// Asynchronously reads the data file and formats the text as a List of strings that can later be parsed into DataRecord objects.
     /// Stores the List in Table.LastReadLines.
     /// </summary>
     /// <remarks>
@@ -251,7 +300,8 @@ public partial class DataTable : ObservableObject
         {
             throw new ArgumentException($"Could not create a DataTable object from the file at '{Path}' because the Process '{ProcessName}' is not defined.");
         }
-        // set up the Table's PageSets
+        // read the file synchronously (once) and set up the Table's PageSets
+        ReadLines();
         Pages = new PageSet(RecordType);
         SearchPages = new PageSet(RecordType);
     }
@@ -270,7 +320,8 @@ public partial class DataTable : ObservableObject
         // confirm that Pages is set to provide Pages of the correct size
         if (Pages.Count < 1 || Pages.Pages[0].MaxLength != PageLength)
         {
-            Pages = new PageSet(LastReadLines, RecordType, PageLength: PageLength);
+            await ReadLinesAsync();
+            Pages = new PageSet(LastReadLines!, RecordType, PageLength: PageLength);
         }
         // get the requested Page
         try

--- a/LotCoMClient/Models/Datasources/DataTable.cs
+++ b/LotCoMClient/Models/Datasources/DataTable.cs
@@ -1,7 +1,5 @@
 using CommunityToolkit.Mvvm.ComponentModel;
 using LotCoMClient.Models.Exceptions;
-using LotCoMClient.Models.Options;
-using System.Linq.Dynamic;
 
 namespace LotCoMClient.Models.Datasources;
 
@@ -53,15 +51,6 @@ public partial class DataTable : ObservableObject
     {
         get {return _recordType;}
         private set {_recordType = value;}
-    }
-
-    private DataTableRecordsState _recordsState = new DataTableRecordsState();
-    /// <summary>
-    /// Holds the Table's current DataRecords State.
-    /// </summary>
-    public DataTableRecordsState RecordsState {
-        get {return _recordsState;}
-        set {_recordsState = value;}
     }
 
     private List<string> _headers = [];
@@ -157,29 +146,6 @@ public partial class DataTable : ObservableObject
         // reverse list to show newest Lines first
         LastReadLines.Reverse();
         return LastReadLines;
-    }
-
-    /// <summary>
-    /// Asynchronously opens, reads, and formats the text in DataTable.Path as a list of DataRecords.
-    /// </summary>
-    /// <exception cref="OperationCanceledException"></exception>
-    /// <exception cref="RecordParseException"></exception>
-    /// <returns>A List of DataRecords.</returns>
-    private async Task<List<DataRecord>> ReadAsync() 
-    {
-        // read the Database Table at the Path property
-        await ReadLinesAsync();
-        // parse the text into individual DataRecord objects as a batch of async Tasks
-        IEnumerable<Task<DataRecord>>? Tasks = LastReadLines.Select(ParseRecordAsync);
-        DataRecord[]? ParseResult = await Task.WhenAll(Tasks);
-        if (ParseResult == null) 
-        {
-            return [];
-        }
-        else 
-        {
-            return ParseResult.ToList();
-        }
     }
 
     /// <summary>
@@ -303,67 +269,6 @@ public partial class DataTable : ObservableObject
     }
 
     /// <summary>
-    /// Asynchronously opens and overwrites the data in DataTable._path with the current list of DataRecords in DataTable._records.
-    /// </summary>
-    /// <exception cref="OperationCanceledException"></exception>
-    /// <returns>A List of DataRecords.</returns>
-    private async Task SaveAsync(List<DataRecord> Records) 
-    {
-        // format the passed DataRecords as single string separated by newlines on a new CPU thread
-        if (Records != null) 
-        {
-            string Text = await Task.Run(() => 
-            {
-                string Formatted = "";
-                foreach (DataRecord _record in Records) 
-                {
-                    Formatted = $"{Formatted}{_record.ToCSV()}\n";
-                }
-                // return the formatted single string
-                return Formatted;
-            });
-            // asynchronously write the single string as text to the Database Table file at _path
-            await File.WriteAllTextAsync(Path, Text);
-        } 
-        else 
-        {
-            throw new OperationCanceledException("Cannot save null to the Database Table file.");
-        }
-    }
-
-    /// <summary>
-    /// Sorts the Table's Records list using SortingProperty as the sort.
-    /// Order can be either 0 or 1, where 0 indicates ascending order and 1 indicates descending.
-    /// Does NOT overwrite with the sorted list.
-    /// </summary>
-    /// <param name="SortingProperty"></param>
-    /// <param name="SortOrder"></param>
-    /// <exception cref="OperationCanceledException"></exception>
-    /// <returns>A List of DataRecords sorted using the Property and Order.</returns>
-    private async Task<List<DataRecord>> SortRecordsAsync(string SortingProperty, int SortOrder) 
-    {
-        if (RecordsState.Current == null) 
-        {
-            throw new OperationCanceledException();
-        }
-        // perform the sort algorithm on a new CPU thread
-        return await Task.Run(() => 
-        {
-            // use LINQ dynamic to sort using the property selected in the sorting field picker
-            List<DataRecord> SortedData = RecordsState.Current
-                .AsQueryable()
-                .OrderBy(SortingProperty)
-                .ToList();
-            // invert the order (ascending by default) if descending sort was selected
-            if (SortOrder == 1) 
-            {
-                SortedData.Reverse();
-            }
-            return SortedData;
-        });
-    }
-
-    /// <summary>
     /// Searches each Line in LastReadLines for a match in ANY field (as a continuous CSV string). 
     /// </summary>
     /// <remarks>
@@ -469,30 +374,6 @@ public partial class DataTable : ObservableObject
     }
 
     /// <summary>
-    /// Retrieves either the Current or LastRead List of DataRecords in the Table.
-    /// </summary>
-    /// <exception cref="SystemException"></exception>
-    /// <returns>A List of DataRecords.</returns>
-    public async Task<List<DataRecord>> RequestRecords() 
-    {
-        return await Task.Run(() => {
-            // return the DataRecords stored in runtime
-            if (RecordsState.Current != null)
-            {
-                return RecordsState.Current;
-            }
-            else if (RecordsState.LastRead != null)
-            {
-                return RecordsState.LastRead;
-            }
-            else 
-            {
-                return [];
-            }
-        });
-    }
-
-    /// <summary>
     /// Confirms that there are Pages in the Table and that they are of the correct Length.
     /// Checks if the requested Page has been parsed into DataRecords and does so if not.
     /// </summary>
@@ -510,68 +391,6 @@ public partial class DataTable : ObservableObject
         }
         // parse DataRecords out of the requested Page of Lines
         return await ParsePageAsync(PageNumber);
-    }
-
-    /// <summary>
-    /// Refreshes the Database Table in runtime.
-    /// </summary>
-    /// <returns>A list of DataRecords currently in the Database Table.</returns>
-    /// <exception cref="SystemException"></exception>
-    public async Task<List<DataRecord>> ReadRecordsAsync() 
-    {
-        // read the DataRecord and return the NotifyTaskCompletion object holding the promised list
-        try 
-        {
-            RecordsState.LastRead = await ReadAsync();
-            RecordsState.Current = RecordsState.LastRead;
-            return RecordsState.LastRead;
-        } 
-        catch (Exception _ex) 
-        {
-            throw new SystemException($"Could not complete the read request due to the following exception:\n {_ex.Message}");
-        }
-    }
-
-    /// <summary>
-    /// Asynchronously saves DataRecords to DataTable.Path and updates DataTable.RecordsState.LastRead in runtime.
-    /// </summary>
-    /// <param name="Records">A List of DataRecords to write to DataTable._path.</param>
-    /// <exception cref="ArgumentException"></exception>
-    /// <exception cref="ArgumentNullException"></exception>
-    /// <exception cref="PathTooLongException"></exception>
-    /// <exception cref="DirectoryNotFoundException"></exception>
-    /// <exception cref="IOException"></exception>
-    /// <exception cref="UnauthorizedAccessException"></exception>
-    /// <exception cref="FileNotFoundException"></exception>
-    /// <exception cref="NotSupportedException"></exception>
-    /// <exception cref="System.Security.SecurityException"></exception>
-    public async Task SaveRecordsAsync(List<DataRecord> Records) 
-    {
-        // save the passed records to the Database table file
-        try 
-        {
-            await SaveAsync(Records);
-        } 
-        catch (Exception _ex) 
-        {
-            throw new FileLoadException($"Failed to save the DataTable to the file '{_path}' due to the following access error:\n{_ex.Message}");
-        }
-        // update the RecordsState property
-        RecordsState.LastRead = await ReadAsync();
-        RecordsState.Current = RecordsState.LastRead;
-    }
-
-    /// <summary>
-    /// Sorts the Table's Records list using SortingProperty as the sort.
-    /// Order can be either 0 or 1, where 0 indicates ascending order and 1 indicates descending.
-    /// </summary>
-    /// <param name="SortingProperty">A Property name applicable to the DataRecord class.</param>
-    /// <param name="Order">0 (ascending) or 1 (descending).</param>
-    /// <returns></returns>
-    public async Task<List<DataRecord>> RequestSort(string SortingProperty, int Order) 
-    {
-        RecordsState.Current = await SortRecordsAsync(SortingProperty, Order);
-        return RecordsState.Current;
     }
 
     /// <summary>

--- a/LotCoMClient/Models/Datasources/DataTable.cs
+++ b/LotCoMClient/Models/Datasources/DataTable.cs
@@ -455,6 +455,7 @@ public partial class DataTable : ObservableObject
         }
         // create a new PageSet with the new SearchResultLines value and return the first Page in that new set
         SearchPages = new PageSet(SearchResultLines, RecordType, PageLength: PageLength);
+        await GoToSearchPages();
         return await SearchPages.GetActivePage();
     }
 }

--- a/LotCoMClient/Models/Datasources/DataTable.cs
+++ b/LotCoMClient/Models/Datasources/DataTable.cs
@@ -323,35 +323,6 @@ public partial class DataTable : ObservableObject
     }
 
     /// <summary>
-    /// Confirms that there are Pages in the Table and that they are of the correct Length.
-    /// Checks if the requested Page has been parsed into DataRecords and does so if not.
-    /// </summary>
-    /// <param name="PageNumber">The Page in Table.Pages to Parse 
-    /// (NOTE: Table.Pages is 0-oriented, so Page Numbers must be 1 less than the actual page number.)
-    /// </param>
-    /// <param name="PageLength">Specifies the maximum number of Lines to include in each Page.</param>
-    /// <returns>A Page object with PageLength DataRecords ready to be displayed.</returns>
-    public async Task<Page> RequestPage(int PageNumber, int PageLength) 
-    {
-        // confirm that Pages is set to provide Pages of the correct size
-        if (BasePages.Count < 1 || BasePages.Pages[0].MaxLength != PageLength)
-        {
-            await ReadLinesAsync();
-            BasePages = new PageSet(LastReadLines!, RecordType, PageLength: PageLength);
-        }
-        // get the requested Page
-        try
-        {
-            await BasePages.SetActivePage(PageNumber);
-            return await BasePages.GetActivePage();
-        }
-        catch
-        {
-            throw new IndexOutOfRangeException();
-        }
-    }
-
-    /// <summary>
     /// Jumps to the first Page in the Table's current Pages (the newest Records).
     /// </summary>
     public async Task GoToFirstPage()
@@ -430,6 +401,35 @@ public partial class DataTable : ObservableObject
         BasePages = new PageSet(LastReadLines!, RecordType, MaxCount, PageLength);
         SearchPages = BasePages;
         ActivePageSet = BasePages;
+    }
+
+    /// <summary>
+    /// Confirms that there are Pages in the Table and that they are of the correct Length.
+    /// Checks if the requested Page has been parsed into DataRecords and does so if not.
+    /// </summary>
+    /// <param name="PageNumber">The Page in Table.Pages to Parse 
+    /// (NOTE: Table.Pages is 0-oriented, so Page Numbers must be 1 less than the actual page number.)
+    /// </param>
+    /// <param name="PageLength">Specifies the maximum number of Lines to include in each Page.</param>
+    /// <param name="MaxCount">(Optional) Set a limit on the number of Pages allowed in the PageSet.</param>
+    /// <returns>A Page object with PageLength DataRecords ready to be displayed.</returns>
+    public async Task<Page> RequestPage(int PageNumber, int PageLength, int MaxCount = -1) 
+    {
+        // confirm that Pages is set to provide Pages of the correct size
+        if (ActivePageSet.Count < 1 || ActivePageSet.Pages[0].MaxLength != PageLength)
+        {
+            await RefreshPages(MaxCount, PageLength);
+        }
+        // get the requested Page
+        try
+        {
+            await ActivePageSet.SetActivePage(PageNumber);
+            return await ActivePageSet.GetActivePage();
+        }
+        catch
+        {
+            throw new IndexOutOfRangeException();
+        }
     }
 
     /// <summary>

--- a/LotCoMClient/Models/Datasources/DataTable.cs
+++ b/LotCoMClient/Models/Datasources/DataTable.cs
@@ -24,9 +24,9 @@ public partial class DataTable : ObservableObject
     private List<string> SearchResultLines = [];
 
     /// <summary>
-    /// Holds a List of Pages created from this Table's data.
+    /// Holds a List of Pages created from this Table's unfiltered data.
     /// </summary>
-    private PageSet Pages;
+    private PageSet BasePages;
 
     /// <summary>
     /// Holds a custom List of Pages created from the latest Search algorithm.
@@ -71,6 +71,16 @@ public partial class DataTable : ObservableObject
     {
         get {return _process;}
         private set {_process = value;}
+    }
+
+    private PageSet _activePageSet = new PageSet(typeof(DataRecord));
+    /// <summary>
+    /// Controls this Table's active PageSet, which is the PageSet the Table displays Pages from.
+    /// </summary>
+    public PageSet ActivePageSet
+    {
+        get {return _activePageSet;}
+        private set {_activePageSet = value;}
     }
 
     /// <summary>
@@ -307,8 +317,9 @@ public partial class DataTable : ObservableObject
         }
         // read the file synchronously (once) and set up the Table's PageSets
         ReadLines();
-        Pages = new PageSet(RecordType);
+        BasePages = new PageSet(RecordType);
         SearchPages = new PageSet(RecordType);
+        ActivePageSet = BasePages;
     }
 
     /// <summary>
@@ -323,15 +334,16 @@ public partial class DataTable : ObservableObject
     public async Task<Page> RequestPage(int PageNumber, int PageLength) 
     {
         // confirm that Pages is set to provide Pages of the correct size
-        if (Pages.Count < 1 || Pages.Pages[0].MaxLength != PageLength)
+        if (BasePages.Count < 1 || BasePages.Pages[0].MaxLength != PageLength)
         {
             await ReadLinesAsync();
-            Pages = new PageSet(LastReadLines!, RecordType, PageLength: PageLength);
+            BasePages = new PageSet(LastReadLines!, RecordType, PageLength: PageLength);
         }
         // get the requested Page
         try
         {
-            return await Pages.GetPage(PageNumber);
+            await BasePages.SetActivePage(PageNumber);
+            return await BasePages.GetActivePage();
         }
         catch
         {
@@ -362,6 +374,57 @@ public partial class DataTable : ObservableObject
         }
         // create a new PageSet with the new SearchResultLines value and return the first Page in that new set
         SearchPages = new PageSet(SearchResultLines, RecordType, PageLength: PageLength);
-        return await SearchPages.GetPage(0);
+        return await SearchPages.GetActivePage();
+    }
+
+    /// <summary>
+    /// Jumps to the first Page in the Table's current Pages (the newest Records).
+    /// </summary>
+    public async Task GoToFirstPage()
+    {
+        await ActivePageSet.GoToFirstPage();
+    }
+
+    /// <summary>
+    /// Goes to the previous Page in the Table's current Pages (if one exists).
+    /// </summary>
+    public async Task GoToPreviousPage()
+    {
+        await ActivePageSet.GoToPreviousPage();
+    }
+
+    /// <summary>
+    /// Jumps to the last Page in the Table's current Pages (the oldest Records).
+    /// </summary>
+    public async Task GoToLastPage()
+    {
+        await ActivePageSet.GoToLastPage();
+    }
+
+    /// <summary>
+    /// Goes to the next Page in the Table's current Pages (if one exists).
+    /// </summary>
+    public async Task GoToNextPage()
+    {
+        await ActivePageSet.GoToLastPage();
+    }
+
+    /// <summary>
+    /// Swaps the Active Page Set to the last generated SearchPages PageSet.
+    /// </summary>
+    /// <returns></returns>
+    public async Task GoToSearchPages()
+    {
+        // set the Active Page Set to use Search Pages and set the Active Page to the first page in the set
+        ActivePageSet = SearchPages;
+        await SearchPages.SetActivePage(0);
+    }
+
+
+    public async Task GoToBasePages()
+    {
+        // set the Active Page Set to use Base Pages and set the Active Page to the first page in the set
+        ActivePageSet = BasePages;
+        await BasePages.SetActivePage(0);
     }
 }

--- a/LotCoMClient/Models/Datasources/DataTable.cs
+++ b/LotCoMClient/Models/Datasources/DataTable.cs
@@ -204,10 +204,17 @@ public partial class DataTable : ObservableObject
     /// <summary>
     /// Parses DataRecords from every Line in a Page and saves those DataRecords in the Page's Page.DataRecords property.
     /// </summary>
-    /// <param name="PageNumber">The Page in Table.Pages to Parse (NOTE: Table.Pages is 0-oriented, so Page Numbers must be 1 less than the actual page number.)</param>
+    /// <param name="PageNumber">The Page in Table.Pages to Parse 
+    /// (NOTE: Table.Pages is 0-oriented, so Page Numbers must be 1 less than the actual page number.)
+    /// </param>
     /// <returns></returns>
     private async Task<Page> ParsePageAsync(int PageNumber)
     {
+        // confirm that the Page hasn't already been parsed out
+        if (Pages[PageNumber].DataRecords.Count > 0) 
+        {
+            return Pages[PageNumber];
+        }
         // parse a DataRecord from every Line in Page.Lines and save it in Page.DataRecords
         IEnumerable<Task<DataRecord>>? ParseTasks = Pages[PageNumber]
             .Lines
@@ -422,6 +429,26 @@ public partial class DataTable : ObservableObject
                 return [];
             }
         });
+    }
+
+    /// <summary>
+    /// Confirms that there are Pages in the Table and that they are of the correct Length.
+    /// Checks if the requested Page has been parsed into DataRecords and does so if not.
+    /// </summary>
+    /// <param name="PageNumber">The Page in Table.Pages to Parse 
+    /// (NOTE: Table.Pages is 0-oriented, so Page Numbers must be 1 less than the actual page number.)
+    /// </param>
+    /// <param name="PageLength">Specifies the maximum number of Lines to include in each Page.</param>
+    /// <returns>A Page object with PageLength DataRecords ready to be displayed.</returns>
+    public async Task<Page> RequestPage(int PageNumber, int PageLength) 
+    {
+        // confirm that there are Pages of the correct size available
+        if (Pages.Count < 1 || Pages[0].MaxLength != PageLength)
+        {
+            await PaginateAsync(PageLength);
+        }
+        // parse DataRecords out of the requested Page of Lines
+        return await ParsePageAsync(PageNumber);
     }
 
     /// <summary>

--- a/LotCoMClient/Models/Datasources/DataTable.cs
+++ b/LotCoMClient/Models/Datasources/DataTable.cs
@@ -292,7 +292,7 @@ public partial class DataTable : ObservableObject
     /// <param name="SearchTerm">The term to match.</param>
     /// <param name="PropertyName">The name of the Property to search in.</param>
     /// <returns>A List of DataRecords that the matching algorithm hits.</returns>
-    private async Task<Page> SearchAsync(string SearchTerm, string PropertyName, int PageLength) 
+    public async Task<Page> SearchAsync(string SearchTerm, string PropertyName, int PageLength) 
     {
         // search in all fields of each DataRecord
         if (PropertyName.Equals("All")) 

--- a/LotCoMClient/Models/Datasources/DataTable.cs
+++ b/LotCoMClient/Models/Datasources/DataTable.cs
@@ -20,6 +20,11 @@ public partial class DataTable : ObservableObject
     /// </summary>
     private List<string> LastReadLines = [];
 
+    /// <summary>
+    /// Holds a List of Pages created from this Table's data.
+    /// </summary>
+    private List<Page> Pages = [];
+
     private string _path = "";
     /// <summary>
     /// The Path of the database table file in the LotCoM database filing system.
@@ -117,13 +122,13 @@ public partial class DataTable : ObservableObject
     }
 
     /// <summary>
-    /// Reads the data file and formats the text as a List of strings that can be counted and later parsed into DataRecord objects.
+    /// Reads the data file and formats the text as a List of strings that can later be parsed into DataRecord objects.
     /// Stores the List in Table.LastReadLines.
     /// </summary>
     /// <remarks>
     /// Does not perform any formatting.
     /// </remarks>
-    /// <returns></returns>
+    /// <returns>A List of Lines as strings.</returns>
     /// <exception cref="OperationCanceledException"></exception>
     private async Task<List<string>> ReadLinesAsync()
     {
@@ -139,6 +144,8 @@ public partial class DataTable : ObservableObject
         }
         // split the text into a list of Line strings and update the cached Lines list
         LastReadLines = await ParseLinesAsync(Text);
+        // reverse list to show newest Lines first
+        LastReadLines.Reverse();
         return LastReadLines;
     }
 
@@ -163,6 +170,35 @@ public partial class DataTable : ObservableObject
         {
             return ParseResult.ToList();
         }
+    }
+
+    /// <summary>
+    /// Creates a List of Page objects from the Lines in LastReadLines and stores them in Table.Pages.
+    /// </summary>
+    /// <param name="PageLength">Specifies the maximum number of Lines to include in each Page.</param>
+    /// <returns></returns>
+    private async Task<List<Page>> PaginateAsync(int PageLength)
+    {
+        // confirm that the Table has Lines stored in the LastReadProperty
+        if (LastReadLines.Count < 1)
+        {
+            await ReadLinesAsync();
+        }
+        // create pages of PageLength Lines, starting with the newest lines
+        int TakenLines = 0;
+        while (TakenLines < LastReadLines.Count)
+        {
+            // take the first PageLength + TakenLines elements from LastReadLines to create a Page
+            Page _page = new Page(PageLength);
+            _page.Lines = LastReadLines
+                .Skip(TakenLines)
+                .Take(PageLength)
+                .ToList();
+            // increment the amount of lines taken and add the Page to the Table
+            TakenLines += PageLength;
+            Pages.Add(_page);
+        }
+        return Pages;
     }
 
     /// <summary>

--- a/LotCoMClient/Models/Datasources/DataTable.cs
+++ b/LotCoMClient/Models/Datasources/DataTable.cs
@@ -352,32 +352,6 @@ public partial class DataTable : ObservableObject
     }
 
     /// <summary>
-    /// Performs a search on all of the current records in the Table.
-    /// If All passed as PropertyName, checks for matches in every field of the Data Record.
-    /// Otherwise, searches for match hits in the singular field passed as PropertyName.
-    /// Builds a new Page set from the search results.
-    /// </summary>
-    /// <param name="SearchTerm">The term to match.</param>
-    /// <param name="PropertyName">The name of the Property to search in.</param>
-    /// <returns>A List of DataRecords that the matching algorithm hits.</returns>
-    public async Task<Page> SearchAsync(string SearchTerm, string PropertyName, int PageLength) 
-    {
-        // search in all fields of each DataRecord
-        if (PropertyName.Equals("All")) 
-        {
-            await SearchAllFieldsAsync(SearchTerm);
-        // search in a singular field of each DataRecord
-        } 
-        else 
-        {
-            await SearchSingleFieldAsync(SearchTerm, PropertyName);
-        }
-        // create a new PageSet with the new SearchResultLines value and return the first Page in that new set
-        SearchPages = new PageSet(SearchResultLines, RecordType, PageLength: PageLength);
-        return await SearchPages.GetActivePage();
-    }
-
-    /// <summary>
     /// Jumps to the first Page in the Table's current Pages (the newest Records).
     /// </summary>
     public async Task GoToFirstPage()
@@ -420,11 +394,67 @@ public partial class DataTable : ObservableObject
         await SearchPages.SetActivePage(0);
     }
 
-
+    /// <summary>
+    /// Swaps the Active Page Set to the last generated BasePages PageSet.
+    /// </summary>
+    /// <returns></returns>
     public async Task GoToBasePages()
     {
         // set the Active Page Set to use Base Pages and set the Active Page to the first page in the set
         ActivePageSet = BasePages;
         await BasePages.SetActivePage(0);
+    }
+
+    /// <summary>
+    /// Creates a new PageSet from the LastReadLines property. Replaces BasePages and SearchPages with this new PageSet.
+    /// </summary>
+    /// <param name="MaxCount"></param>
+    /// <param name="PageLength"></param>
+    /// <returns></returns>
+    /// <exception cref="OperationCanceledException"></exception>
+    public async Task RefreshPages(int MaxCount, int PageLength)
+    {
+        // confirm that there are Lines to create a PageSet from
+        if (LastReadLines is null) 
+        {
+            try
+            {
+                await ReadLinesAsync();
+            }
+            catch
+            {
+                throw new OperationCanceledException();
+            }
+        }
+        // create a new PageSet from LastReadLines using the passed PageLength and MaxCount
+        BasePages = new PageSet(LastReadLines!, RecordType, MaxCount, PageLength);
+        SearchPages = BasePages;
+        ActivePageSet = BasePages;
+    }
+
+    /// <summary>
+    /// Performs a search on all of the current records in the Table.
+    /// If All passed as PropertyName, checks for matches in every field of the Data Record.
+    /// Otherwise, searches for match hits in the singular field passed as PropertyName.
+    /// Builds a new Page set from the search results.
+    /// </summary>
+    /// <param name="SearchTerm">The term to match.</param>
+    /// <param name="PropertyName">The name of the Property to search in.</param>
+    /// <returns>A List of DataRecords that the matching algorithm hits.</returns>
+    public async Task<Page> SearchAsync(string SearchTerm, string PropertyName, int PageLength) 
+    {
+        // search in all fields of each DataRecord
+        if (PropertyName.Equals("All")) 
+        {
+            await SearchAllFieldsAsync(SearchTerm);
+        // search in a singular field of each DataRecord
+        } 
+        else 
+        {
+            await SearchSingleFieldAsync(SearchTerm, PropertyName);
+        }
+        // create a new PageSet with the new SearchResultLines value and return the first Page in that new set
+        SearchPages = new PageSet(SearchResultLines, RecordType, PageLength: PageLength);
+        return await SearchPages.GetActivePage();
     }
 }

--- a/LotCoMClient/Models/Datasources/DataTable.cs
+++ b/LotCoMClient/Models/Datasources/DataTable.cs
@@ -13,6 +13,26 @@ public partial class DataTable : ObservableObject
     /// </summary>
     private readonly RecordParser Parser = new RecordParser();
 
+    /// <summary>
+    /// Holds a List of strings resulting from the latest file read.
+    /// </summary>
+    private List<string> LastReadLines = [];
+
+    /// <summary>
+    /// Holds a List of strings that are matching results of the latest Search algorithm.
+    /// </summary>
+    private List<string> SearchResultLines = [];
+
+    /// <summary>
+    /// Holds a List of Pages created from this Table's data.
+    /// </summary>
+    private PageSet Pages;
+
+    /// <summary>
+    /// Holds a custom List of Pages created from the latest Search algorithm.
+    /// </summary>
+    private PageSet SearchPages;
+
     private string _path = "";
     /// <summary>
     /// The Path of the database table file in the LotCoM database filing system.
@@ -54,24 +74,9 @@ public partial class DataTable : ObservableObject
     }
 
     /// <summary>
-    /// Holds a List of strings resulting from the latest file read.
+    /// Returns the total count of Records in the Data Table file (as of the last ReadLines call).
     /// </summary>
-    private List<string> LastReadLines = [];
-
-    /// <summary>
-    /// Holds a List of strings that are matching results of the latest Search algorithm.
-    /// </summary>
-    private List<string> SearchResultLines = [];
-
-    /// <summary>
-    /// Holds a List of Pages created from this Table's data.
-    /// </summary>
-    private PageSet Pages;
-
-    /// <summary>
-    /// Holds a custom List of Pages created from the latest Search algorithm.
-    /// </summary>
-    private PageSet SearchPages;
+    public int RecordCount => LastReadLines.Count;
 
     /// <summary>
     /// Parses a DataRecord of the DataTable's RecordType from CSVLine.

--- a/LotCoMClient/Models/Datasources/DataTable.cs
+++ b/LotCoMClient/Models/Datasources/DataTable.cs
@@ -13,26 +13,6 @@ public partial class DataTable : ObservableObject
     /// </summary>
     private readonly RecordParser Parser = new RecordParser();
 
-    /// <summary>
-    /// Holds a List of strings resulting from the latest file read.
-    /// </summary>
-    private List<string> LastReadLines = [];
-
-    /// <summary>
-    /// Holds a List of strings that are matching results of the latest Search algorithm.
-    /// </summary>
-    private List<string> SearchResultLines = [];
-
-    /// <summary>
-    /// Holds a List of Pages created from this Table's data.
-    /// </summary>
-    private List<Page> Pages = [];
-
-    /// <summary>
-    /// Holds a custom List of Pages created from the latest Search algorithm.
-    /// </summary>
-    private List<Page> SearchPages = [];
-
     private string _path = "";
     /// <summary>
     /// The Path of the database table file in the LotCoM database filing system.
@@ -72,6 +52,26 @@ public partial class DataTable : ObservableObject
         get {return _process;}
         private set {_process = value;}
     }
+
+    /// <summary>
+    /// Holds a List of strings resulting from the latest file read.
+    /// </summary>
+    private List<string> LastReadLines = [];
+
+    /// <summary>
+    /// Holds a List of strings that are matching results of the latest Search algorithm.
+    /// </summary>
+    private List<string> SearchResultLines = [];
+
+    /// <summary>
+    /// Holds a List of Pages created from this Table's data.
+    /// </summary>
+    private PageSet Pages;
+
+    /// <summary>
+    /// Holds a custom List of Pages created from the latest Search algorithm.
+    /// </summary>
+    private PageSet SearchPages;
 
     /// <summary>
     /// Parses a DataRecord of the DataTable's RecordType from CSVLine.
@@ -146,126 +146,6 @@ public partial class DataTable : ObservableObject
         // reverse list to show newest Lines first
         LastReadLines.Reverse();
         return LastReadLines;
-    }
-
-    /// <summary>
-    /// Creates a List of Page objects from the Lines in LastReadLines and stores them in Table.Pages.
-    /// </summary>
-    /// <param name="PageLength">Specifies the maximum number of Lines to include in each Page.</param>
-    /// <returns></returns>
-    private async Task<List<Page>> PaginateAsync(int PageLength)
-    {
-        // confirm that the Table has Lines stored in the LastReadProperty
-        if (LastReadLines.Count < 1)
-        {
-            await ReadLinesAsync();
-        }
-        // create pages of PageLength Lines, starting with the newest lines
-        int TakenLines = 0;
-        while (TakenLines < LastReadLines.Count)
-        {
-            // take the first PageLength + TakenLines elements from LastReadLines to create a Page
-            Page _page = new Page(PageLength);
-            _page.Lines = LastReadLines
-                .Skip(TakenLines)
-                .Take(PageLength)
-                .ToList();
-            // increment the amount of lines taken and add the Page to the Table
-            TakenLines += PageLength;
-            Pages.Add(_page);
-        }
-        return Pages;
-    }
-
-    /// <summary>
-    /// Parses DataRecords from every Line in a Page and saves those DataRecords in the Page's Page.DataRecords property.
-    /// </summary>
-    /// <param name="PageNumber">The Page in Table.Pages to Parse 
-    /// (NOTE: Table.Pages is 0-oriented, so Page Numbers must be 1 less than the actual page number.)
-    /// </param>
-    /// <returns></returns>
-    private async Task<Page> ParsePageAsync(int PageNumber)
-    {
-        // confirm that the Page hasn't already been parsed out
-        if (Pages[PageNumber].DataRecords.Count > 0) 
-        {
-            return Pages[PageNumber];
-        }
-        // parse a DataRecord from every Line in Page.Lines and save it in Page.DataRecords
-        IEnumerable<Task<DataRecord>>? ParseTasks = Pages[PageNumber]
-            .Lines
-            .Select(ParseRecordAsync);
-        DataRecord[]? ParseResults = await Task.WhenAll(ParseTasks);
-        // confirm that the Parse was successful and add the Parsed DataRecords to Page.DataRecords
-        if (ParseResults is null) 
-        {
-            Pages[PageNumber].DataRecords = [];
-        }
-        Pages[PageNumber].DataRecords = ParseResults!.ToList();
-        // return the updated Page object
-        return Pages[PageNumber];
-    }
-
-    /// <summary>
-    /// Creates a List of Page objects from the Lines in SearchResultLines and stores them in Table.SearchPages.
-    /// </summary>
-    /// <param name="PageLength">Specifies the maximum number of Lines to include in each Page.</param>
-    /// <returns></returns>
-    private async Task<List<Page>> PaginateSearchResultsAsync(int PageLength)
-    {
-        return await Task.Run(() => 
-        {
-            // confirm that the Table has Lines stored in the SearchResultLines
-            if (SearchResultLines.Count < 1)
-            {
-                SearchPages = [];
-                return SearchPages;
-            }
-            // create pages of PageLength Lines, starting with the newest lines
-            int TakenLines = 0;
-            while (TakenLines < SearchResultLines.Count)
-            {
-                // take the first PageLength + TakenLines elements from SearchResultLines to create a Page
-                Page _page = new Page(PageLength);
-                _page.Lines = SearchResultLines
-                    .Skip(TakenLines)
-                    .Take(PageLength)
-                    .ToList();
-                // increment the amount of lines taken and add the Page to the Table
-                TakenLines += PageLength;
-                SearchPages.Add(_page);
-            }
-            return SearchPages;
-        });
-    }
-
-    /// <summary>
-    /// Parses DataRecords from every Line in a Page and saves those DataRecords in the Page's Page.DataRecords property.
-    /// </summary>
-    /// <param name="PageNumber">The Page in Table.SearchPages to Parse 
-    /// (NOTE: Table.SearchPages is 0-oriented, so Page Numbers must be 1 less than the actual page number.)
-    /// </param>
-    /// <returns></returns>
-    private async Task<Page> ParseSearchResultsPageAsync(int PageNumber)
-    {
-        // confirm that the Page hasn't already been parsed out
-        if (SearchPages[PageNumber].DataRecords.Count > 0) 
-        {
-            return SearchPages[PageNumber];
-        }
-        // parse a DataRecord from every Line in Page.Lines and save it in Page.DataRecords
-        IEnumerable<Task<DataRecord>>? ParseTasks = SearchPages[PageNumber]
-            .Lines
-            .Select(ParseRecordAsync);
-        DataRecord[]? ParseResults = await Task.WhenAll(ParseTasks);
-        // confirm that the Parse was successful and add the Parsed DataRecords to Page.DataRecords
-        if (ParseResults is null) 
-        {
-            SearchPages[PageNumber].DataRecords = [];
-        }
-        SearchPages[PageNumber].DataRecords = ParseResults!.ToList();
-        // return the updated Page object
-        return SearchPages[PageNumber];
     }
 
     /// <summary>
@@ -371,6 +251,9 @@ public partial class DataTable : ObservableObject
         {
             throw new ArgumentException($"Could not create a DataTable object from the file at '{Path}' because the Process '{ProcessName}' is not defined.");
         }
+        // set up the Table's PageSets
+        Pages = new PageSet(RecordType);
+        SearchPages = new PageSet(RecordType);
     }
 
     /// <summary>
@@ -384,13 +267,20 @@ public partial class DataTable : ObservableObject
     /// <returns>A Page object with PageLength DataRecords ready to be displayed.</returns>
     public async Task<Page> RequestPage(int PageNumber, int PageLength) 
     {
-        // confirm that there are Pages of the correct size available
-        if (Pages.Count < 1 || Pages[0].MaxLength != PageLength)
+        // confirm that Pages is set to provide Pages of the correct size
+        if (Pages.Count < 1 || Pages.Pages[0].MaxLength != PageLength)
         {
-            await PaginateAsync(PageLength);
+            Pages = new PageSet(LastReadLines, RecordType, PageLength: PageLength);
         }
-        // parse DataRecords out of the requested Page of Lines
-        return await ParsePageAsync(PageNumber);
+        // get the requested Page
+        try
+        {
+            return await Pages.GetPage(PageNumber);
+        }
+        catch
+        {
+            throw new IndexOutOfRangeException();
+        }
     }
 
     /// <summary>
@@ -414,9 +304,8 @@ public partial class DataTable : ObservableObject
         {
             await SearchSingleFieldAsync(SearchTerm, PropertyName);
         }
-        // paginate the new LastReadLines value and Parse the first Page in that new set
-        await PaginateSearchResultsAsync(PageLength);
-        await ParseSearchResultsPageAsync(0);
-        return SearchPages[0];
+        // create a new PageSet with the new SearchResultLines value and return the first Page in that new set
+        SearchPages = new PageSet(SearchResultLines, RecordType, PageLength: PageLength);
+        return await SearchPages.GetPage(0);
     }
 }

--- a/LotCoMClient/Models/Datasources/DataTable.cs
+++ b/LotCoMClient/Models/Datasources/DataTable.cs
@@ -54,10 +54,15 @@ public partial class DataTable : ObservableObject
         private set {_headers = value;}
     }
 
+    private Process? _process = null;
     /// <summary>
-    /// Observable property exposing the Name of the Process producing the Records in this Table.
+    /// The Process producing the Records in this Table.
     /// </summary>
-    public Process TableProcess;
+    public Process? Process 
+    {
+        get {return _process;}
+        private set {_process = value;}
+    }
 
     /// <summary>
     /// Parses a DataRecord of the DataTable's RecordType from CSVLine.
@@ -307,7 +312,7 @@ public partial class DataTable : ObservableObject
             .Replace(".txt", "");
         try
         {
-            TableProcess = new ProcessData().GetIndividualProcess(ProcessName);
+            Process = new ProcessData().GetIndividualProcess(ProcessName);
         }
         catch
         {

--- a/LotCoMClient/Models/Datasources/DataTable.cs
+++ b/LotCoMClient/Models/Datasources/DataTable.cs
@@ -325,33 +325,33 @@ public partial class DataTable : ObservableObject
     /// <summary>
     /// Jumps to the first Page in the Table's current Pages (the newest Records).
     /// </summary>
-    public async Task GoToFirstPage()
+    public async Task<Page> GoToFirstPage()
     {
-        await ActivePageSet.GoToFirstPage();
+        return await ActivePageSet.GoToFirstPage();
     }
 
     /// <summary>
     /// Goes to the previous Page in the Table's current Pages (if one exists).
     /// </summary>
-    public async Task GoToPreviousPage()
+    public async Task<Page> GoToPreviousPage()
     {
-        await ActivePageSet.GoToPreviousPage();
+        return await ActivePageSet.GoToPreviousPage();
     }
 
     /// <summary>
     /// Jumps to the last Page in the Table's current Pages (the oldest Records).
     /// </summary>
-    public async Task GoToLastPage()
+    public async Task<Page> GoToLastPage()
     {
-        await ActivePageSet.GoToLastPage();
+        return await ActivePageSet.GoToLastPage();
     }
 
     /// <summary>
     /// Goes to the next Page in the Table's current Pages (if one exists).
     /// </summary>
-    public async Task GoToNextPage()
+    public async Task<Page> GoToNextPage()
     {
-        await ActivePageSet.GoToNextPage();
+        return await ActivePageSet.GoToNextPage();
     }
 
     /// <summary>
@@ -381,9 +381,9 @@ public partial class DataTable : ObservableObject
     /// </summary>
     /// <param name="MaxCount"></param>
     /// <param name="PageLength"></param>
-    /// <returns></returns>
+    /// <returns>The currently Active Page of the new PageSet.</returns>
     /// <exception cref="OperationCanceledException"></exception>
-    public async Task RefreshPages(int MaxCount, int PageLength)
+    public async Task<Page> RefreshPages(int MaxCount, int PageLength)
     {
         // confirm that there are Lines to create a PageSet from
         if (LastReadLines is null) 
@@ -401,6 +401,7 @@ public partial class DataTable : ObservableObject
         BasePages = new PageSet(LastReadLines!, RecordType, MaxCount, PageLength);
         SearchPages = BasePages;
         ActivePageSet = BasePages;
+        return await ActivePageSet.GetActivePage();
     }
 
     /// <summary>
@@ -436,11 +437,11 @@ public partial class DataTable : ObservableObject
     /// Performs a search on all of the current records in the Table.
     /// If All passed as PropertyName, checks for matches in every field of the Data Record.
     /// Otherwise, searches for match hits in the singular field passed as PropertyName.
-    /// Builds a new Page set from the search results.
+    /// Builds a new PageSet from the search results and activates the new SearchPages PageSet.
     /// </summary>
     /// <param name="SearchTerm">The term to match.</param>
     /// <param name="PropertyName">The name of the Property to search in.</param>
-    /// <returns>A List of DataRecords that the matching algorithm hits.</returns>
+    /// <returns>The ActivePage of the new SearchPages PageSet.</returns>
     public async Task<Page> SearchAsync(string SearchTerm, string PropertyName, int PageLength) 
     {
         // search in all fields of each DataRecord

--- a/LotCoMClient/Models/Datasources/DataTable.cs
+++ b/LotCoMClient/Models/Datasources/DataTable.cs
@@ -54,11 +54,10 @@ public partial class DataTable : ObservableObject
         private set {_headers = value;}
     }
 
-    [ObservableProperty]
     /// <summary>
     /// Observable property exposing the Name of the Process producing the Records in this Table.
     /// </summary>
-    public partial string TableProcess {get; set;}
+    public Process TableProcess;
 
     /// <summary>
     /// Parses a DataRecord of the DataTable's RecordType from CSVLine.
@@ -300,12 +299,20 @@ public partial class DataTable : ObservableObject
         } 
         else 
         {
-            throw new ArgumentException($"Could not create a DataTable object from the file at {Path}.");
+            throw new ArgumentException($"Could not create a DataTable object from the file at '{Path}'.");
         }
         // set the Table's Process using the filename
-        TableProcess = Path
+        string ProcessName = Path
             .Split("\\")[^1]
             .Replace(".txt", "");
+        try
+        {
+            TableProcess = new ProcessData().GetIndividualProcess(ProcessName);
+        }
+        catch
+        {
+            throw new ArgumentException($"Could not create a DataTable object from the file at '{Path}' because the Process '{ProcessName}' is not defined.");
+        }
     }
 
     /// <summary>

--- a/LotCoMClient/Models/Datasources/DataTable.cs
+++ b/LotCoMClient/Models/Datasources/DataTable.cs
@@ -202,6 +202,28 @@ public partial class DataTable : ObservableObject
     }
 
     /// <summary>
+    /// Parses DataRecords from every Line in a Page and saves those DataRecords in the Page's Page.DataRecords property.
+    /// </summary>
+    /// <param name="PageNumber">The Page in Table.Pages to Parse (NOTE: Table.Pages is 0-oriented, so Page Numbers must be 1 less than the actual page number.)</param>
+    /// <returns></returns>
+    private async Task<Page> ParsePageAsync(int PageNumber)
+    {
+        // parse a DataRecord from every Line in Page.Lines and save it in Page.DataRecords
+        IEnumerable<Task<DataRecord>>? ParseTasks = Pages[PageNumber]
+            .Lines
+            .Select(ParseRecordAsync);
+        DataRecord[]? ParseResults = await Task.WhenAll(ParseTasks);
+        // confirm that the Parse was successful and add the Parsed DataRecords to Page.DataRecords
+        if (ParseResults is null) 
+        {
+            Pages[PageNumber].DataRecords = [];
+        }
+        Pages[PageNumber].DataRecords = ParseResults!.ToList();
+        // return the updated Page object
+        return Pages[PageNumber];
+    }
+
+    /// <summary>
     /// Asynchronously opens and overwrites the data in DataTable._path with the current list of DataRecords in DataTable._records.
     /// </summary>
     /// <exception cref="OperationCanceledException"></exception>

--- a/LotCoMClient/Models/Datasources/DataTable.cs
+++ b/LotCoMClient/Models/Datasources/DataTable.cs
@@ -15,6 +15,11 @@ public partial class DataTable : ObservableObject
     /// </summary>
     private readonly RecordParser Parser = new RecordParser();
 
+    /// <summary>
+    /// Holds a List of strings resulting from the latest file read.
+    /// </summary>
+    private List<string> LastReadLines = [];
+
     private string _path = "";
     /// <summary>
     /// The Path of the database table file in the LotCoM database filing system.
@@ -112,12 +117,15 @@ public partial class DataTable : ObservableObject
     }
 
     /// <summary>
-    /// Asynchronously opens, reads, and formats the text in DataTable.Path as a list of DataRecords.
+    /// Reads the data file and formats the text as a List of strings that can be counted and later parsed into DataRecord objects.
+    /// Stores the List in Table.LastReadLines.
     /// </summary>
+    /// <remarks>
+    /// Does not perform any formatting.
+    /// </remarks>
+    /// <returns></returns>
     /// <exception cref="OperationCanceledException"></exception>
-    /// <exception cref="RecordParseException"></exception>
-    /// <returns>A List of DataRecords.</returns>
-    private async Task<List<DataRecord>> ReadAsync() 
+    private async Task<List<string>> ReadLinesAsync()
     {
         // read the Database Table at the Path property
         string Text;
@@ -129,9 +137,23 @@ public partial class DataTable : ObservableObject
         {
             throw new OperationCanceledException($"Failed to read the Database file: '{Path}' due to the following exception:\n{_ex.Message}.");
         }
+        // split the text into a list of Line strings and update the cached Lines list
+        LastReadLines = await ParseLinesAsync(Text);
+        return LastReadLines;
+    }
+
+    /// <summary>
+    /// Asynchronously opens, reads, and formats the text in DataTable.Path as a list of DataRecords.
+    /// </summary>
+    /// <exception cref="OperationCanceledException"></exception>
+    /// <exception cref="RecordParseException"></exception>
+    /// <returns>A List of DataRecords.</returns>
+    private async Task<List<DataRecord>> ReadAsync() 
+    {
+        // read the Database Table at the Path property
+        await ReadLinesAsync();
         // parse the text into individual DataRecord objects as a batch of async Tasks
-        List<string> RecordLines = await ParseLinesAsync(Text);
-        IEnumerable<Task<DataRecord>>? Tasks = RecordLines.Select(ParseRecordAsync);
+        IEnumerable<Task<DataRecord>>? Tasks = LastReadLines.Select(ParseRecordAsync);
         DataRecord[]? ParseResult = await Task.WhenAll(Tasks);
         if (ParseResult == null) 
         {

--- a/LotCoMClient/Models/Datasources/DataTable.cs
+++ b/LotCoMClient/Models/Datasources/DataTable.cs
@@ -21,9 +21,19 @@ public partial class DataTable : ObservableObject
     private List<string> LastReadLines = [];
 
     /// <summary>
+    /// Holds a List of strings that are matching results of the latest Search algorithm.
+    /// </summary>
+    private List<string> SearchResultLines = [];
+
+    /// <summary>
     /// Holds a List of Pages created from this Table's data.
     /// </summary>
     private List<Page> Pages = [];
+
+    /// <summary>
+    /// Holds a custom List of Pages created from the latest Search algorithm.
+    /// </summary>
+    private List<Page> SearchPages = [];
 
     private string _path = "";
     /// <summary>
@@ -231,6 +241,68 @@ public partial class DataTable : ObservableObject
     }
 
     /// <summary>
+    /// Creates a List of Page objects from the Lines in SearchResultLines and stores them in Table.SearchPages.
+    /// </summary>
+    /// <param name="PageLength">Specifies the maximum number of Lines to include in each Page.</param>
+    /// <returns></returns>
+    private async Task<List<Page>> PaginateSearchResultsAsync(int PageLength)
+    {
+        return await Task.Run(() => 
+        {
+            // confirm that the Table has Lines stored in the SearchResultLines
+            if (SearchResultLines.Count < 1)
+            {
+                SearchPages = [];
+                return SearchPages;
+            }
+            // create pages of PageLength Lines, starting with the newest lines
+            int TakenLines = 0;
+            while (TakenLines < SearchResultLines.Count)
+            {
+                // take the first PageLength + TakenLines elements from SearchResultLines to create a Page
+                Page _page = new Page(PageLength);
+                _page.Lines = SearchResultLines
+                    .Skip(TakenLines)
+                    .Take(PageLength)
+                    .ToList();
+                // increment the amount of lines taken and add the Page to the Table
+                TakenLines += PageLength;
+                SearchPages.Add(_page);
+            }
+            return SearchPages;
+        });
+    }
+
+    /// <summary>
+    /// Parses DataRecords from every Line in a Page and saves those DataRecords in the Page's Page.DataRecords property.
+    /// </summary>
+    /// <param name="PageNumber">The Page in Table.SearchPages to Parse 
+    /// (NOTE: Table.SearchPages is 0-oriented, so Page Numbers must be 1 less than the actual page number.)
+    /// </param>
+    /// <returns></returns>
+    private async Task<Page> ParseSearchResultsPageAsync(int PageNumber)
+    {
+        // confirm that the Page hasn't already been parsed out
+        if (SearchPages[PageNumber].DataRecords.Count > 0) 
+        {
+            return SearchPages[PageNumber];
+        }
+        // parse a DataRecord from every Line in Page.Lines and save it in Page.DataRecords
+        IEnumerable<Task<DataRecord>>? ParseTasks = SearchPages[PageNumber]
+            .Lines
+            .Select(ParseRecordAsync);
+        DataRecord[]? ParseResults = await Task.WhenAll(ParseTasks);
+        // confirm that the Parse was successful and add the Parsed DataRecords to Page.DataRecords
+        if (ParseResults is null) 
+        {
+            SearchPages[PageNumber].DataRecords = [];
+        }
+        SearchPages[PageNumber].DataRecords = ParseResults!.ToList();
+        // return the updated Page object
+        return SearchPages[PageNumber];
+    }
+
+    /// <summary>
     /// Asynchronously opens and overwrites the data in DataTable._path with the current list of DataRecords in DataTable._records.
     /// </summary>
     /// <exception cref="OperationCanceledException"></exception>
@@ -292,84 +364,73 @@ public partial class DataTable : ObservableObject
     }
 
     /// <summary>
-    /// Searches each DataRecord for a match in ANY field (as a continuous string). 
+    /// Searches each Line in LastReadLines for a match in ANY field (as a continuous CSV string). 
     /// </summary>
+    /// <remarks>
+    /// Updates LastReadLines to contain the matching Lines.
+    /// </remarks>
     /// <param name="SearchTerm">The term to match.</param>
     /// <exception cref="OperationCanceledException"></exception>
-    /// <returns>A List of DataRecords that were match hits for the search.</returns>
-    private async Task<List<DataRecord>> SearchAllFieldsAsync(string SearchTerm) 
+    /// <returns>A List of strings that were match hits for the search.</returns>
+    private async Task<List<string>> SearchAllFieldsAsync(string SearchTerm) 
     {
-        if (RecordsState.LastRead == null) 
+        // confirm that there are Lines to search through
+        if (LastReadLines is null) 
         {
-            throw new OperationCanceledException();
-        }
-        // perform the search algorithm on a new CPU thread
-        return await Task.Run(() => 
-        {
-            // convert each DataRecord in RecordsState.LastRead to a CSV Line and check for a hit
-            List<DataRecord> SearchHits = [];
-            foreach (DataRecord _record in RecordsState.LastRead) 
+            try
             {
-                string _recordString = _record.ToCSV();
-                if (_recordString.Contains(SearchTerm)) 
-                {
-                    SearchHits.Add(_record);
-                }
+                await ReadLinesAsync();
             }
-            return SearchHits;
-        });
+            catch
+            {
+                throw new OperationCanceledException();
+            }
+        }
+        SearchResultLines = LastReadLines!;
+        // return all hits for the search term
+        SearchResultLines = SearchResultLines!
+            .Where(x => x
+            .Contains(SearchTerm))
+            .ToList();
+        return SearchResultLines;
     }
 
     /// <summary>
-    /// Searches each DataRecord for a match in PropertyName field.
+    /// Searches each Line in LastReadLines for a match in PropertyName field.
     /// </summary>
+    /// <remarks>
+    /// Updates LastReadLines to contain the matching Lines.
+    /// </remarks>
     /// <param name="SearchTerm">The term to match.</param>
     /// <param name="PropertyName">The name of the Property to search in.</param>
-    /// <returns>A List of DataRecords that were match hits for the search.</returns>
-    private async Task<List<DataRecord>> SearchSingleFieldAsync(string SearchTerm, string PropertyName) 
+    /// <exception cref="OperationCanceledException"></exception>
+    /// <returns>A List of strings that were match hits for the search.</returns>
+    private async Task<List<string>> SearchSingleFieldAsync(string SearchTerm, string PropertyName) 
     {
-        if (RecordsState.LastRead == null) 
+        // first find all Lines with hits in any field
+        SearchResultLines = await SearchAllFieldsAsync(SearchTerm);
+        // convert all Hits into DataRecords
+        IEnumerable<Task<DataRecord>>? ParseTasks = SearchResultLines!
+            .Select(ParseRecordAsync);
+        DataRecord[]? ParseResults = await Task.WhenAll(ParseTasks);
+        // confirm that the Parse was successful
+        if (ParseResults is null) 
         {
-            throw new OperationCanceledException();
+            return [];
         }
-        return await Task.Run(() => 
-        {
-            // convert each DataRecord in _records to a CSV Line and check for a hit
-            List<DataRecord> SearchHits = [];
-            SearchHits = RecordsState.LastRead.Where(x => x.GetType()!
-                .GetProperty(PropertyName)!
-                .GetValue(x)!
-                .ToString()!
-                .Contains(SearchTerm))
-                .ToList();
-            return SearchHits;
-        });
-    }
-
-    /// <summary>
-    /// Runs one of the two Search Algorithms. 
-    /// The chosen Algorithm depends on the value of PropertyName.
-    /// </summary>
-    /// <param name="SearchTerm"></param>
-    /// <param name="PropertyName"></param>
-    /// <returns></returns>
-    private async Task<List<DataRecord>> SearchAsync(string SearchTerm, string PropertyName) 
-    {
-        return await Task.Run(async () => 
-        {
-            List<DataRecord> Hits;
-            // search in all fields of each DataRecord
-            if (PropertyName.Equals("All")) 
-            {
-                Hits = await SearchAllFieldsAsync(SearchTerm);
-            // search in a singular field of each DataRecord
-            } 
-            else 
-            {
-                Hits = await SearchSingleFieldAsync(SearchTerm, PropertyName);
-            }
-            return Hits;
-        });
+        // now find all DataRecords with a hit in the specific field requested
+        List<DataRecord> RecordHits = ParseResults
+            .Where(x => x.GetType()!
+            .GetProperty(PropertyName)!
+            .GetValue(x)!
+            .ToString()!
+            .Contains(SearchTerm))
+            .ToList();
+        // convert those DataRecords back to strings and return
+        SearchResultLines = RecordHits
+            .Select(x => x.ToCSV())
+            .ToList();
+        return SearchResultLines;
     }
 
     /// <summary>
@@ -514,17 +575,29 @@ public partial class DataTable : ObservableObject
     }
 
     /// <summary>
-    /// Performs a search on the current data in _records. 
+    /// Performs a search on all of the current records in the Table.
     /// If All passed as PropertyName, checks for matches in every field of the Data Record.
     /// Otherwise, searches for match hits in the singular field passed as PropertyName.
+    /// Builds a new Page set from the search results.
     /// </summary>
     /// <param name="SearchTerm">The term to match.</param>
     /// <param name="PropertyName">The name of the Property to search in.</param>
     /// <returns>A List of DataRecords that the matching algorithm hits.</returns>
-    public async Task<List<DataRecord>> RequestSearch(string SearchTerm, string PropertyName) 
+    private async Task<Page> SearchAsync(string SearchTerm, string PropertyName, int PageLength) 
     {
-        // perform the search algorithm on a new CPU thread
-        RecordsState.Current = await SearchAsync(SearchTerm, PropertyName);
-        return RecordsState.Current;
+        // search in all fields of each DataRecord
+        if (PropertyName.Equals("All")) 
+        {
+            await SearchAllFieldsAsync(SearchTerm);
+        // search in a singular field of each DataRecord
+        } 
+        else 
+        {
+            await SearchSingleFieldAsync(SearchTerm, PropertyName);
+        }
+        // paginate the new LastReadLines value and Parse the first Page in that new set
+        await PaginateSearchResultsAsync(PageLength);
+        await ParseSearchResultsPageAsync(0);
+        return SearchPages[0];
     }
 }

--- a/LotCoMClient/Models/Datasources/DataTable.cs
+++ b/LotCoMClient/Models/Datasources/DataTable.cs
@@ -317,7 +317,7 @@ public partial class DataTable : ObservableObject
         }
         // read the file synchronously (once) and set up the Table's PageSets
         ReadLines();
-        BasePages = new PageSet(RecordType);
+        BasePages = new PageSet(LastReadLines, RecordType);
         SearchPages = new PageSet(RecordType);
         ActivePageSet = BasePages;
     }
@@ -406,7 +406,7 @@ public partial class DataTable : ObservableObject
     /// </summary>
     public async Task GoToNextPage()
     {
-        await ActivePageSet.GoToLastPage();
+        await ActivePageSet.GoToNextPage();
     }
 
     /// <summary>

--- a/LotCoMClient/Models/Datasources/Page.cs
+++ b/LotCoMClient/Models/Datasources/Page.cs
@@ -1,0 +1,24 @@
+namespace LotCoMClient.Models.Datasources;
+
+public class Page(int PageLength)
+{
+    /// <summary>
+    /// The maximum number of Lines/DataRecords this Page can hold.
+    /// </summary>
+    public int MaxLength = PageLength;
+
+    /// <summary>
+    /// Returns the current number of DataRecords contained in this Page.
+    /// </summary>
+    public int Count => DataRecords.Count;
+
+    /// <summary>
+    /// Contains an unparsed list of Lines assigned to this Page.
+    /// </summary>
+    public List<string> Lines = [];
+
+    /// <summary>
+    /// Contains a parsed list of DataRecord objects assigned to this Page.
+    /// </summary>
+    public List<DataRecord> DataRecords = [];
+}

--- a/LotCoMClient/Models/Datasources/Page.cs
+++ b/LotCoMClient/Models/Datasources/Page.cs
@@ -4,8 +4,13 @@ namespace LotCoMClient.Models.Datasources;
 /// Creates a set of Lines and/or DataRecords that can be displayed in a ListView.
 /// </summary>
 /// <param name="PageLength">The maximum number of Lines/DataRecords this Page can hold.</param>
-public class Page(int PageLength)
+public class Page(int PageLength, Type RecordType)
 {
+    /// <summary>
+    /// Sets the type of DataRecord that this Page can hold.
+    /// </summary>
+    private Type RecordType = RecordType;
+
     /// <summary>
     /// The maximum number of Lines/DataRecords this Page can hold.
     /// </summary>
@@ -25,4 +30,47 @@ public class Page(int PageLength)
     /// Contains a parsed list of DataRecord objects assigned to this Page.
     /// </summary>
     public List<DataRecord> DataRecords = [];
+
+    /// <summary>
+    /// Parses a DataRecord of the Page's RecordType from CSVLine.
+    /// </summary>
+    /// <param name="Parser">A RecordParser object.</param>
+    /// <param name="CSVLine">A CSV-formatted string.</param>
+    /// <returns></returns>
+    private async Task<DataRecord> ParseRecordAsync(RecordParser Parser, string CSVLine)
+    {
+        // attempt to parse the proper type of DataRecord from the CSV Line
+        DataRecord ParsedRecord;
+        if (RecordType == typeof(PrintRecord)) 
+        {
+            ParsedRecord = await Parser.ParsePrintRecordFromCSVAsync(CSVLine);
+        // parse a ScanRecord
+        } 
+        else 
+        {
+            ParsedRecord = await Parser.ParseScanRecordFromCSVAsync(CSVLine);
+        }
+        // return the parsed DataRecord
+        return ParsedRecord;
+    }
+
+    /// <summary>
+    /// Parses all of the Lines in Page.Lines into DataRecords of Page.RecordType.
+    /// Stores the DataRecords in Page.DataRecords.
+    /// </summary>
+    public async Task GenerateDataRecords() 
+    {
+        // create a new RecordParser instance
+        RecordParser Parser = new RecordParser();
+        // parse a DataRecord from every Line in Lines and save it in DataRecords
+        IEnumerable<Task<DataRecord>>? ParseTasks = Lines
+            .Select(x => ParseRecordAsync(Parser, x));
+        DataRecord[]? ParseResults = await Task.WhenAll(ParseTasks);
+        // confirm that the Parse was successful and add the Parsed DataRecords to DataRecords
+        if (ParseResults is null) 
+        {
+            DataRecords = [];
+        }
+        DataRecords = ParseResults!.ToList();
+    }
 }

--- a/LotCoMClient/Models/Datasources/Page.cs
+++ b/LotCoMClient/Models/Datasources/Page.cs
@@ -11,17 +11,22 @@ public partial class Page(int PageLength, Type RecordType) : ObservableObject()
     /// <summary>
     /// Sets the type of DataRecord that this Page can hold.
     /// </summary>
-    private Type RecordType = RecordType;
+    private readonly Type RecordType = RecordType;
 
     /// <summary>
     /// The maximum number of Lines/DataRecords this Page can hold.
     /// </summary>
-    public int MaxLength = PageLength;
+    public readonly int MaxLength = PageLength;
 
     /// <summary>
     /// Returns the current number of DataRecords contained in this Page.
     /// </summary>
     public int Count => DataRecords.Count;
+
+    /// <summary>
+    /// Whether or not the Page's Lines have been Parsed into DataRecords.
+    /// </summary>
+    public bool IsParsed = false;
 
     /// <summary>
     /// Contains an unparsed list of Lines assigned to this Page.
@@ -76,5 +81,7 @@ public partial class Page(int PageLength, Type RecordType) : ObservableObject()
             DataRecords = [];
         }
         DataRecords = ParseResults!.ToList();
+        // set the Page as Parsed
+        IsParsed = true;
     }
 }

--- a/LotCoMClient/Models/Datasources/Page.cs
+++ b/LotCoMClient/Models/Datasources/Page.cs
@@ -1,10 +1,12 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+
 namespace LotCoMClient.Models.Datasources;
 
 /// <summary>
 /// Creates a set of Lines and/or DataRecords that can be displayed in a ListView.
 /// </summary>
 /// <param name="PageLength">The maximum number of Lines/DataRecords this Page can hold.</param>
-public class Page(int PageLength, Type RecordType)
+public partial class Page(int PageLength, Type RecordType) : ObservableObject()
 {
     /// <summary>
     /// Sets the type of DataRecord that this Page can hold.
@@ -24,12 +26,14 @@ public class Page(int PageLength, Type RecordType)
     /// <summary>
     /// Contains an unparsed list of Lines assigned to this Page.
     /// </summary>
-    public List<string> Lines = [];
+    [ObservableProperty]
+    public partial List<string> Lines {get; set;} = [];
 
     /// <summary>
     /// Contains a parsed list of DataRecord objects assigned to this Page.
     /// </summary>
-    public List<DataRecord> DataRecords = [];
+    [ObservableProperty]
+    public partial List<DataRecord> DataRecords {get; set;} = [];
 
     /// <summary>
     /// Parses a DataRecord of the Page's RecordType from CSVLine.

--- a/LotCoMClient/Models/Datasources/Page.cs
+++ b/LotCoMClient/Models/Datasources/Page.cs
@@ -1,5 +1,9 @@
 namespace LotCoMClient.Models.Datasources;
 
+/// <summary>
+/// Creates a set of Lines and/or DataRecords that can be displayed in a ListView.
+/// </summary>
+/// <param name="PageLength">The maximum number of Lines/DataRecords this Page can hold.</param>
 public class Page(int PageLength)
 {
     /// <summary>

--- a/LotCoMClient/Models/Datasources/PageSet.cs
+++ b/LotCoMClient/Models/Datasources/PageSet.cs
@@ -21,11 +21,6 @@ public class PageSet
     private readonly Type RecordType;
 
     /// <summary>
-    /// Sets the currently active Page for this PageSet. 
-    /// </summary>
-    private int ActivePageIndex = 0;
-
-    /// <summary>
     /// Returns the Page object that is currently active in this PageSet.
     /// </summary>
     private Page ActivePage => Pages[ActivePageIndex];
@@ -47,6 +42,15 @@ public class PageSet
             _pages = value;
         }
     }
+    
+    /// <summary>
+    /// Sets the currently active Page for this PageSet. 
+    /// </summary>
+    public int ActivePageIndex
+    {
+        get;
+        private set;
+    } = 0;
 
     /// <summary>
     /// Sets the maximum number of Lines allowed in each Page in this PageSet.

--- a/LotCoMClient/Models/Datasources/PageSet.cs
+++ b/LotCoMClient/Models/Datasources/PageSet.cs
@@ -26,6 +26,11 @@ public class PageSet
     private Page ActivePage => Pages[ActivePageIndex];
 
     /// <summary>
+    /// Returns whether or not the PageSet has a Page immediately before the current Active Page.
+    /// </summary>
+    private bool HasPrevious => ActivePageIndex - 1 >= 0;
+
+    /// <summary>
     /// Returns whether or not the PageSet has a Page immediately after the current Active Page.
     /// </summary>
     private bool HasNext => ActivePageIndex + 1 < PageCount;
@@ -233,12 +238,8 @@ public class PageSet
     /// </summary>
     public async Task<Page> GoToPreviousPage()
     {
-        // bar from going below 0
-        if (ActivePageIndex == 0)
-        {
-            ActivePageIndex = 0;
-        }
-        else
+        // confirm the PageSet has a Page before the current one
+        if (HasPrevious)
         {
             ActivePageIndex -= 1;
         }

--- a/LotCoMClient/Models/Datasources/PageSet.cs
+++ b/LotCoMClient/Models/Datasources/PageSet.cs
@@ -11,11 +11,6 @@ public class PageSet
     private int MaxCount = -1;
 
     /// <summary>
-    /// Sets the maximum number of Lines allowed in each Page in this PageSet.
-    /// </summary>
-    private int PageLength = 25;
-
-    /// <summary>
     /// Sets the type of DataRecord that the Pages in this PageSet can hold.
     /// </summary>
     private Type RecordType;
@@ -32,6 +27,11 @@ public class PageSet
             _pages = value;
         }
     }
+
+    /// <summary>
+    /// Sets the maximum number of Lines allowed in each Page in this PageSet.
+    /// </summary>
+    public int PageLength = 25;
 
     /// <summary>
     /// The number of Page objects in this PageSet.
@@ -124,6 +124,7 @@ public class PageSet
     /// Returns a Page with DataRecords.
     /// </summary>
     /// <param name="PageNumber">The index of the requested Page in PageSet.Pages. 0-oriented.</param>
+    /// <exception cref="IndexOutOfRangeException"></exception>
     /// <returns></returns>
     public async Task<Page> GetPage(int PageNumber)
     {

--- a/LotCoMClient/Models/Datasources/PageSet.cs
+++ b/LotCoMClient/Models/Datasources/PageSet.cs
@@ -217,16 +217,17 @@ public class PageSet
     /// <summary>
     /// Jumps to the first Page in the PageSet (the newest Records).
     /// </summary>
-    public async Task GoToFirstPage()
+    public async Task<Page> GoToFirstPage()
     {
         ActivePageIndex = 0;
         await GenerateActivePage();
+        return ActivePage;
     }
 
     /// <summary>
     /// Goes to the previous Page in the PageSet (if one exists).
     /// </summary>
-    public async Task GoToPreviousPage()
+    public async Task<Page> GoToPreviousPage()
     {
         // bar from going below 0
         if (ActivePageIndex == 0)
@@ -238,21 +239,23 @@ public class PageSet
             ActivePageIndex -= 1;
         }
         await GenerateActivePage();
+        return ActivePage;
     }
 
     /// <summary>
     /// Jumps to the last Page in the PageSet (the oldest Records).
     /// </summary>
-    public async Task GoToLastPage()
+    public async Task<Page> GoToLastPage()
     {
         ActivePageIndex = PageCount - 1;
         await GenerateActivePage();
+        return ActivePage;
     }
 
     /// <summary>
     /// Goes to the next Page in the PageSet (if one exists).
     /// </summary>
-    public async Task GoToNextPage()
+    public async Task<Page> GoToNextPage()
     {
         // confirm the PageSet has a Page after the current one
         if (HasNext)
@@ -260,6 +263,7 @@ public class PageSet
             ActivePageIndex += 1;
         }
         await GenerateActivePage();
+        return ActivePage;
     }
 
     /// <summary>

--- a/LotCoMClient/Models/Datasources/PageSet.cs
+++ b/LotCoMClient/Models/Datasources/PageSet.cs
@@ -28,7 +28,7 @@ public class PageSet
     /// <summary>
     /// Returns whether or not the PageSet has a Page immediately after the current Active Page.
     /// </summary>
-    private bool HasNext => ActivePageIndex + 1 < PageCount - 1;
+    private bool HasNext => ActivePageIndex + 1 < PageCount;
 
     private List<Page> _pages = [];
     /// <summary>

--- a/LotCoMClient/Models/Datasources/PageSet.cs
+++ b/LotCoMClient/Models/Datasources/PageSet.cs
@@ -33,7 +33,7 @@ public class PageSet
     /// <summary>
     /// Returns whether or not the PageSet has a Page immediately after the current Active Page.
     /// </summary>
-    private bool HasNext => ActivePageIndex + 1 < Count - 1;
+    private bool HasNext => ActivePageIndex + 1 < PageCount - 1;
 
     private List<Page> _pages = [];
     /// <summary>
@@ -56,7 +56,12 @@ public class PageSet
     /// <summary>
     /// The number of Page objects in this PageSet.
     /// </summary>
-    public int Count => Pages.Count;
+    public int PageCount => Pages.Count;
+
+    /// <summary>
+    /// The total number of entries in this PageSet (totalled from each included Page object).
+    /// </summary>
+    public int EntryCount => GetTotalEntryCount();
 
     /// <summary>
     /// Whether this PageSet can contain more Pages or not.
@@ -240,7 +245,7 @@ public class PageSet
     /// </summary>
     public async Task GoToLastPage()
     {
-        ActivePageIndex = Count - 1;
+        ActivePageIndex = PageCount - 1;
         await GenerateActivePage();
     }
 
@@ -255,5 +260,19 @@ public class PageSet
             ActivePageIndex += 1;
         }
         await GenerateActivePage();
+    }
+
+    /// <summary>
+    /// Calculates a Total of all entries in the PageSet's individual Pages.
+    /// </summary>
+    /// <returns></returns>
+    public int GetTotalEntryCount()
+    {
+        int TotalCount = 0;
+        foreach (Page _page in Pages)
+        {
+            TotalCount += _page.Lines.Count;
+        }
+        return TotalCount;
     }
 }

--- a/LotCoMClient/Models/Datasources/PageSet.cs
+++ b/LotCoMClient/Models/Datasources/PageSet.cs
@@ -3,13 +3,35 @@ namespace LotCoMClient.Models.Datasources;
 /// <summary>
 /// Provides a control structure for a set of Page objects that can be used in the same context.
 /// </summary>
-/// <param name="MaxCount">(Optional) Constrains the amount of Pages that are allowed in the PageSet.</param>
-public class PageSet(int MaxCount = -1)
+public class PageSet
 {
     /// <summary>
     /// Sets a maximum number of Pages allowed in this PageSet.
     /// </summary>
-    private int MaxCount = MaxCount;
+    private int MaxCount = -1;
+
+    /// <summary>
+    /// Sets the maximum number of Lines allowed in each Page in this PageSet.
+    /// </summary>
+    private int PageLength = 25;
+
+    /// <summary>
+    /// Sets the type of DataRecord that the Pages in this PageSet can hold.
+    /// </summary>
+    private Type RecordType;
+
+    private List<Page> _pages = [];
+    /// <summary>
+    /// The Page objects included in this PageSet.
+    /// </summary>
+    public List<Page> Pages
+    {
+        get {return _pages;}
+        private set
+        {
+            _pages = value;
+        }
+    }
 
     /// <summary>
     /// The number of Page objects in this PageSet.
@@ -32,16 +54,87 @@ public class PageSet(int MaxCount = -1)
         }
     }
 
-    private List<Page> _pages = [];
     /// <summary>
-    /// The Page objects included in this PageSet.
+    /// Creates a List of Page objects from Lines.
     /// </summary>
-    public List<Page> Pages
+    /// <param name="Lines">A List of Lines to create Pages from.</param>
+    /// <returns></returns>
+    private List<Page> Paginate(List<string> Lines)
     {
-        get {return _pages;}
-        private set
+        // create pages of PageLength Lines, starting with the newest lines
+        List<Page> GeneratedPages = [];
+        int TakenLines = 0;
+        while (TakenLines < Lines.Count)
         {
-            _pages = value;
+            // take the first PageLength + TakenLines elements from Lines to create a Page
+            Page _page = new Page(PageLength, RecordType);
+            _page.Lines = Lines
+                .Skip(TakenLines)
+                .Take(PageLength)
+                .ToList();
+            // increment the amount of lines taken and add the Page to the Table
+            TakenLines += PageLength;
+            GeneratedPages.Add(_page);
         }
+        return GeneratedPages;
+    }
+
+    /// <summary>
+    /// Creates a new, empty PageSet.
+    /// </summary>
+    /// <param name="MaxCount">(Optional) Constrains the amount of Pages that are allowed in the PageSet.</param>
+    /// <param name="PageLength">
+    /// (Optional) Sets the maximum number of Lines that are allowed in each Page in the PageSet.
+    /// Default is 25 Lines per Page object.
+    /// </param>
+    public PageSet(Type RecordType, int MaxCount = -1, int PageLength = 25)
+    {
+        this.MaxCount = MaxCount;
+        this.PageLength = PageLength;
+        this.RecordType = RecordType;
+    }
+
+    /// <summary>
+    /// Creates a new PageSet and pre-populates it with Pages created from Lines.
+    /// </summary>
+    /// <param name="Lines">A List of strings to use as Lines for each Page in the PageSet.</param>
+    /// <param name="MaxCount">(Optional) Constrains the amount of Pages that are allowed in the PageSet.</param>
+    /// <param name="PageLength">
+    /// (Optional) Sets the maximum number of Lines that are allowed in each Page in the PageSet.
+    /// Default is 25 Lines per Page object.
+    /// </param>
+    public PageSet(List<string> Lines, Type RecordType, int MaxCount = -1, int PageLength = 25)
+    {
+        this.MaxCount = MaxCount;
+        this.PageLength = PageLength;
+        this.RecordType = RecordType;
+        // paginate Lines and set the Pages property
+        List<Page> GeneratedPages = Paginate(Lines);
+        if (MaxCount != -1)
+        {
+            Pages = GeneratedPages.Take(MaxCount).ToList();
+        }
+        else
+        {
+            Pages = GeneratedPages;
+        }
+    }
+
+    /// <summary>
+    /// Returns a Page with DataRecords.
+    /// </summary>
+    /// <param name="PageNumber">The index of the requested Page in PageSet.Pages. 0-oriented.</param>
+    /// <returns></returns>
+    public async Task<Page> GetPage(int PageNumber)
+    {
+        // confirm that a Page exists at the requested Page Number
+        if (Count - 1 < PageNumber) 
+        {
+            throw new IndexOutOfRangeException($"There is no Page at the requested index {PageNumber}.");
+        }
+        Page RequestedPage = Pages[PageNumber];
+        // populate the Page's DataRecords property
+        await RequestedPage.GenerateDataRecords();
+        return RequestedPage;
     }
 }

--- a/LotCoMClient/Models/Datasources/PageSet.cs
+++ b/LotCoMClient/Models/Datasources/PageSet.cs
@@ -11,9 +11,29 @@ public class PageSet
     private int MaxCount = -1;
 
     /// <summary>
+    /// Returns whether or not the Page has a set MaxCount.
+    /// </summary>
+    private bool IsLimitedSize => MaxCount != -1;
+
+    /// <summary>
     /// Sets the type of DataRecord that the Pages in this PageSet can hold.
     /// </summary>
     private Type RecordType;
+
+    /// <summary>
+    /// Sets the currently active Page for this PageSet. 
+    /// </summary>
+    private int ActivePageIndex = 0;
+
+    /// <summary>
+    /// Returns the Page object that is currently active in this PageSet.
+    /// </summary>
+    private Page ActivePage => Pages[ActivePageIndex];
+
+    /// <summary>
+    /// Returns whether or not the PageSet has a Page immediately after the current Active Page.
+    /// </summary>
+    private bool HasNext => ActivePageIndex + 1 < Count - 1;
 
     private List<Page> _pages = [];
     /// <summary>
@@ -46,7 +66,7 @@ public class PageSet
     {
         get 
         {
-            if (MaxCount == -1)
+            if (!IsLimitedSize)
             {
                 return true;
             }
@@ -110,7 +130,7 @@ public class PageSet
         this.RecordType = RecordType;
         // paginate Lines and set the Pages property
         List<Page> GeneratedPages = Paginate(Lines);
-        if (MaxCount != -1)
+        if (IsLimitedSize)
         {
             Pages = GeneratedPages.Take(MaxCount).ToList();
         }
@@ -137,5 +157,103 @@ public class PageSet
         // populate the Page's DataRecords property
         await RequestedPage.GenerateDataRecords();
         return RequestedPage;
+    }
+
+    /// <summary>
+    /// Returns the PageSet's current Active Page object.
+    /// </summary>
+    /// <remarks>
+    /// Throws IndexOutOfRangeException if there was no Page at Pages[ActivePageIndex].
+    /// </remarks>
+    /// <returns></returns>
+    /// <exception cref="IndexOutOfRangeException"></exception>
+    public Page GetActivePage() {
+        // confirm a Page exists at the ActivePageIndex and return it
+        try
+        {
+            return ActivePage;
+        }
+        catch
+        {
+            throw new IndexOutOfRangeException("There is no Page at the set ActivePageIndex.");
+        }
+    }
+
+    /// <summary>
+    /// Sets the PageSet's Active Page by setting ActivePageIndex. 
+    /// </summary>
+    /// <remarks>
+    /// Cannot be set to integer values lower than 0 (negative integers).
+    /// Cannot exceed the PageSet's maximum Page count (if set).
+    /// Throws IndexOutOfRangeException if there is no Page object at Pages[PageNumber].
+    /// </remarks>
+    /// <param name="PageNumber"></param>
+    /// <exception cref="IndexOutOfRangeException"></exception>
+    public void SetActivePage(int PageNumber)
+    {
+        // bar from setting to negative indexes and exceeding a set MaxCount
+        if (PageNumber < 0)
+        {
+            PageNumber = 0;
+        }
+        if (IsLimitedSize && PageNumber > MaxCount - 1)
+        {
+            PageNumber = MaxCount - 1;
+        }
+        // confirm that there is a Page at the requested index
+        try
+        {
+            _ = Pages[PageNumber];
+            // if this line is reached, there was a Page at PageNumber index
+            ActivePageIndex = PageNumber;
+        }
+        catch
+        {
+            throw new IndexOutOfRangeException("There is no Page at the requested Index.");
+        }
+    }
+
+    /// <summary>
+    /// Jumps to the first Page in the PageSet (the newest Records).
+    /// </summary>
+    public void GoToFirstPage()
+    {
+        ActivePageIndex = 0;
+    }
+
+    /// <summary>
+    /// Goes to the previous Page in the PageSet (if one exists).
+    /// </summary>
+    public void GoToPreviousPage()
+    {
+        // bar from going below 0
+        if (ActivePageIndex == 0)
+        {
+            ActivePageIndex = 0;
+        }
+        else
+        {
+            ActivePageIndex -= 1;
+        }
+    }
+
+    /// <summary>
+    /// Jumps to the last Page in the PageSet (the oldest Records).
+    /// </summary>
+    public void GoToLastPage()
+    {
+        ActivePageIndex = Count - 1;
+    }
+
+    /// <summary>
+    /// Goes to the next Page in the PageSet (if one exists).
+    /// </summary>
+    public void GoToNextPage()
+    {
+        // confirm the PageSet has a Page after the current one
+        if (HasNext)
+        {
+            ActivePageIndex += 1;
+        }
     }
 }

--- a/LotCoMClient/Models/Datasources/PageSet.cs
+++ b/LotCoMClient/Models/Datasources/PageSet.cs
@@ -8,7 +8,7 @@ public class PageSet
     /// <summary>
     /// Sets a maximum number of Pages allowed in this PageSet.
     /// </summary>
-    private int MaxCount = -1;
+    private readonly int MaxCount = -1;
 
     /// <summary>
     /// Returns whether or not the Page has a set MaxCount.
@@ -18,7 +18,7 @@ public class PageSet
     /// <summary>
     /// Sets the type of DataRecord that the Pages in this PageSet can hold.
     /// </summary>
-    private Type RecordType;
+    private readonly Type RecordType;
 
     /// <summary>
     /// Sets the currently active Page for this PageSet. 
@@ -100,6 +100,19 @@ public class PageSet
     }
 
     /// <summary>
+    /// Parses the Lines of the PageSet's Active Page so it can be displayed.
+    /// </summary>
+    /// <returns></returns>
+    private async Task GenerateActivePage()
+    {
+        // Parse the Active Page so it can be displayed
+        if (!ActivePage.IsParsed)
+        {
+            await ActivePage.GenerateDataRecords();
+        }
+    }
+
+    /// <summary>
     /// Creates a new, empty PageSet.
     /// </summary>
     /// <param name="MaxCount">(Optional) Constrains the amount of Pages that are allowed in the PageSet.</param>
@@ -141,25 +154,6 @@ public class PageSet
     }
 
     /// <summary>
-    /// Returns a Page with DataRecords.
-    /// </summary>
-    /// <param name="PageNumber">The index of the requested Page in PageSet.Pages. 0-oriented.</param>
-    /// <exception cref="IndexOutOfRangeException"></exception>
-    /// <returns></returns>
-    public async Task<Page> GetPage(int PageNumber)
-    {
-        // confirm that a Page exists at the requested Page Number
-        if (Count - 1 < PageNumber) 
-        {
-            throw new IndexOutOfRangeException($"There is no Page at the requested index {PageNumber}.");
-        }
-        Page RequestedPage = Pages[PageNumber];
-        // populate the Page's DataRecords property
-        await RequestedPage.GenerateDataRecords();
-        return RequestedPage;
-    }
-
-    /// <summary>
     /// Returns the PageSet's current Active Page object.
     /// </summary>
     /// <remarks>
@@ -167,10 +161,11 @@ public class PageSet
     /// </remarks>
     /// <returns></returns>
     /// <exception cref="IndexOutOfRangeException"></exception>
-    public Page GetActivePage() {
+    public async Task<Page> GetActivePage() {
         // confirm a Page exists at the ActivePageIndex and return it
         try
         {
+            await GenerateActivePage();
             return ActivePage;
         }
         catch
@@ -189,7 +184,7 @@ public class PageSet
     /// </remarks>
     /// <param name="PageNumber"></param>
     /// <exception cref="IndexOutOfRangeException"></exception>
-    public void SetActivePage(int PageNumber)
+    public async Task SetActivePage(int PageNumber)
     {
         // bar from setting to negative indexes and exceeding a set MaxCount
         if (PageNumber < 0)
@@ -211,20 +206,22 @@ public class PageSet
         {
             throw new IndexOutOfRangeException("There is no Page at the requested Index.");
         }
+        await GenerateActivePage();
     }
 
     /// <summary>
     /// Jumps to the first Page in the PageSet (the newest Records).
     /// </summary>
-    public void GoToFirstPage()
+    public async Task GoToFirstPage()
     {
         ActivePageIndex = 0;
+        await GenerateActivePage();
     }
 
     /// <summary>
     /// Goes to the previous Page in the PageSet (if one exists).
     /// </summary>
-    public void GoToPreviousPage()
+    public async Task GoToPreviousPage()
     {
         // bar from going below 0
         if (ActivePageIndex == 0)
@@ -235,25 +232,28 @@ public class PageSet
         {
             ActivePageIndex -= 1;
         }
+        await GenerateActivePage();
     }
 
     /// <summary>
     /// Jumps to the last Page in the PageSet (the oldest Records).
     /// </summary>
-    public void GoToLastPage()
+    public async Task GoToLastPage()
     {
         ActivePageIndex = Count - 1;
+        await GenerateActivePage();
     }
 
     /// <summary>
     /// Goes to the next Page in the PageSet (if one exists).
     /// </summary>
-    public void GoToNextPage()
+    public async Task GoToNextPage()
     {
         // confirm the PageSet has a Page after the current one
         if (HasNext)
         {
             ActivePageIndex += 1;
         }
+        await GenerateActivePage();
     }
 }

--- a/LotCoMClient/Models/Datasources/PageSet.cs
+++ b/LotCoMClient/Models/Datasources/PageSet.cs
@@ -1,0 +1,47 @@
+namespace LotCoMClient.Models.Datasources;
+
+/// <summary>
+/// Provides a control structure for a set of Page objects that can be used in the same context.
+/// </summary>
+/// <param name="MaxCount">(Optional) Constrains the amount of Pages that are allowed in the PageSet.</param>
+public class PageSet(int MaxCount = -1)
+{
+    /// <summary>
+    /// Sets a maximum number of Pages allowed in this PageSet.
+    /// </summary>
+    private int MaxCount = MaxCount;
+
+    /// <summary>
+    /// The number of Page objects in this PageSet.
+    /// </summary>
+    public int Count => Pages.Count;
+
+    /// <summary>
+    /// Whether this PageSet can contain more Pages or not.
+    /// Always true for unlimited PageSets (MaxCount = -1).
+    /// </summary>
+    public bool HasSpace
+    {
+        get 
+        {
+            if (MaxCount == -1)
+            {
+                return true;
+            }
+            return Pages.Count < MaxCount;
+        }
+    }
+
+    private List<Page> _pages = [];
+    /// <summary>
+    /// The Page objects included in this PageSet.
+    /// </summary>
+    public List<Page> Pages
+    {
+        get {return _pages;}
+        private set
+        {
+            _pages = value;
+        }
+    }
+}

--- a/LotCoMClient/Models/Datasources/PrintRecord.cs
+++ b/LotCoMClient/Models/Datasources/PrintRecord.cs
@@ -16,7 +16,7 @@ namespace LotCoMClient.Models.Datasources;
 /// <param name="RecordTime">The Time assigned to this record.</param>
 /// <param name="RecordShift">The Shift Number assigned to this record.</param>
 /// <param name="OperatorID">The Operator ID assigned to this record.</param>
-public partial class PrintRecord(Process RecordProcess, Part RecordPart, string Quantity, string JBKNumber, string LotNumber, string DeburrJBKNumber, string DieNumber, string ModelNumber, string HeatNumber, string RecordDate, string RecordTime, string RecordShift, string OperatorID): DataRecord(RecordProcess, RecordPart, Quantity, JBKNumber, LotNumber, DeburrJBKNumber, DieNumber, ModelNumber, HeatNumber, RecordDate, RecordTime, RecordShift, OperatorID, null) 
+public partial class PrintRecord(Process RecordProcess, Part RecordPart, string Quantity, string JBKNumber, string LotNumber, string DeburrJBKNumber, string DieNumber, string ModelNumber, string HeatNumber, string RecordDate, string RecordTime, string RecordShift, string OperatorID): DataRecord(RecordProcess, RecordPart, Quantity, JBKNumber, LotNumber, DeburrJBKNumber, DieNumber, ModelNumber, HeatNumber, RecordDate, RecordTime, RecordShift, OperatorID, null, null, null) 
 {
     /// <summary>
     /// Converts a DataRecord base class type object into a PrintRecord object (explicit cast).

--- a/LotCoMClient/Models/Datasources/ProcessData.cs
+++ b/LotCoMClient/Models/Datasources/ProcessData.cs
@@ -214,7 +214,6 @@ public class ProcessData()
     {
         if (!AreProcessesLoaded) 
         {
-            Console.WriteLine("Reading from GetAllProcesses()...");
             // load the data from the Masterlist
             JObject NewRead = LoadData();
             // get the list of Processes in the Masterlist
@@ -251,7 +250,6 @@ public class ProcessData()
         {
             CachedProcesses = await Task.Run(async () => 
             {
-                Console.WriteLine("Reading from GetAllProcessesAsync()...");
                 // load the data from the Masterlist
                 JObject NewRead = await LoadDataAsync();
                 // return the list of Processes in the Masterlist
@@ -286,7 +284,6 @@ public class ProcessData()
     {
         if (!AreDepartmentsLoaded) 
         {
-            Console.WriteLine("Reading from GetAllDepartments()...");
             // load the data from the Masterlist
             JObject NewRead = LoadData();
             // get the list of Departments in the Masterlist
@@ -322,7 +319,6 @@ public class ProcessData()
         {
             CachedDepartments = await Task.Run(async () => 
             {
-                Console.WriteLine("Reading from GetAllDepartmentsAsync()...");
                 // load the data from the Masterlist
                 JObject NewRead = await LoadDataAsync();
                 // get the list of Departments in the Masterlist

--- a/LotCoMClient/Models/Datasources/RecordParser.cs
+++ b/LotCoMClient/Models/Datasources/RecordParser.cs
@@ -253,6 +253,8 @@ public partial class RecordParser()
         {
             DataRecord BaseRecord = await ParseBaseDataRecord(SplitLine);
             BaseRecord.ScanAddress = ScanAddress;
+            BaseRecord.ProductionDate = RecordDate;
+            BaseRecord.ProductionTime = RecordTime;
             ParsedRecord = ScanRecord.ConvertFromBase(BaseRecord);
             // Why swap the RecordDate and ProductionDate properties:
             //   ParseBaseDataRecord parses the ProductionDate from the Record,

--- a/LotCoMClient/Models/Datasources/RecordParser.cs
+++ b/LotCoMClient/Models/Datasources/RecordParser.cs
@@ -30,23 +30,24 @@ public partial class RecordParser()
     private static partial Regex GenerateIPAddressRegex();
     
     /// <summary>
-    /// Asynchronously checks if the first element of a split CSV Line is an IP address.
+    /// Asynchronously checks if the third element (IP Address field location) of a split CSV Line is an IP address.
     /// </summary>
     /// <param name="SplitCSVLine">A CSV Line that has already been split by commas.</param>
-    /// <returns>Null if the first element is not an IP address; the IP address if it is.</returns>
-    private async Task<string?> ParseIPAddressAsync(List<string> SplitCSVLine) 
+    /// <returns>The IP address.</returns>
+    /// <exception cref="RecordParseException"></exception>
+    private static async Task<string?> ParseIPAddressAsync(List<string> SplitCSVLine) 
     {
         return await Task.Run(() => 
         {
-            // peek the first element and test it as an IP Address using a Regex pattern
-            if (IPAddressRegex.IsMatch(SplitCSVLine[0])) 
+            // peek the third element and test it as an IP Address using a Regex pattern
+            if (IPAddressRegex.IsMatch(SplitCSVLine[2])) 
             {
                 // return the first field (confirmed as an IP Address)
-                return SplitCSVLine[0];
+                return SplitCSVLine[2];
             } 
             else 
             {
-                return null;
+                throw new RecordParseException($"Cannot parse an IP Address from '{SplitCSVLine[2]}'.");
             }
         });
     }
@@ -229,23 +230,41 @@ public partial class RecordParser()
             .ToList();
         // test for an IP Address
         string? ScanAddress;
-        ScanAddress = await ParseIPAddressAsync(SplitLine);
-        // remove the IP address from the SplitLine list (if parsed)
-        if (ScanAddress is null) 
+        try
         {
-            throw new RecordParseException();
+            ScanAddress = await ParseIPAddressAsync(SplitLine);
+            // remove the IP address from the SplitLine list (if parsed)
+            SplitLine.RemoveAt(2);
         }
-        else 
+        catch (Exception _ex)
         {
-            SplitLine.RemoveAt(0);
+            throw new RecordParseException(_ex.Message);
         }
-        // parse a base DataRecord, apply the IP address value, and convert to ScanRecord object
+        // remove the Record Date from the CSV line and save it to be swapped with the production time
+        List<string> Timestamp = SplitLine[1]
+            .Split("-")
+            .ToList();
+        string RecordDate = Timestamp[0];
+        string RecordTime = Timestamp[1];
+        SplitLine.RemoveAt(1);
+        // parse a base DataRecord and convert it to a ScanRecord
         ScanRecord ParsedRecord;
         try
         {
             DataRecord BaseRecord = await ParseBaseDataRecord(SplitLine);
-            BaseRecord.ScanAddress = ScanAddress;
             ParsedRecord = ScanRecord.ConvertFromBase(BaseRecord);
+            // Why swap the RecordDate and ProductionDate properties:
+            //   ParseBaseDataRecord parses the ProductionDate from the Record,
+            //   assuming it is the only Date value in the Record.
+            //   ScanRecords are not the same and contain both RecordDates and
+            //   ProductionDates, since the Record could be Printed one day and
+            //   not be scanned for a week
+            ParsedRecord.ProductionDate = ParsedRecord.RecordDate;
+            ParsedRecord.ProductionTime = ParsedRecord.RecordTime;
+            ParsedRecord.RecordDate = RecordDate;
+            ParsedRecord.RecordTime = RecordTime;
+            // save the IP Address as well
+            ParsedRecord.ScanAddress = ScanAddress;
         }
         catch
         {

--- a/LotCoMClient/Models/Datasources/RecordParser.cs
+++ b/LotCoMClient/Models/Datasources/RecordParser.cs
@@ -252,6 +252,7 @@ public partial class RecordParser()
         try
         {
             DataRecord BaseRecord = await ParseBaseDataRecord(SplitLine);
+            BaseRecord.ScanAddress = ScanAddress;
             ParsedRecord = ScanRecord.ConvertFromBase(BaseRecord);
             // Why swap the RecordDate and ProductionDate properties:
             //   ParseBaseDataRecord parses the ProductionDate from the Record,
@@ -263,8 +264,6 @@ public partial class RecordParser()
             ParsedRecord.ProductionTime = ParsedRecord.RecordTime;
             ParsedRecord.RecordDate = RecordDate;
             ParsedRecord.RecordTime = RecordTime;
-            // save the IP Address as well
-            ParsedRecord.ScanAddress = ScanAddress;
         }
         catch
         {

--- a/LotCoMClient/Models/Datasources/ScanRecord.cs
+++ b/LotCoMClient/Models/Datasources/ScanRecord.cs
@@ -17,7 +17,9 @@ namespace LotCoMClient.Models.Datasources;
 /// <param name="RecordShift">The Shift Number assigned to this record.</param>
 /// <param name="OperatorID">The Operator ID assigned to this record.</param>
 /// <param name="ScanAddress">The IP Address of the Scanner producing this record.</param>
-public partial class ScanRecord(Process RecordProcess, Part RecordPart, string Quantity, string JBKNumber, string LotNumber, string DeburrJBKNumber, string DieNumber, string ModelNumber, string HeatNumber, string RecordDate, string RecordTime, string RecordShift, string OperatorID, string ScanAddress): DataRecord(RecordProcess, RecordPart, Quantity, JBKNumber, LotNumber, DeburrJBKNumber, DieNumber, ModelNumber, HeatNumber, RecordDate, RecordTime, RecordShift, OperatorID, ScanAddress) 
+/// <param name="ProductionDate">The Production Date of the Record's Label.</param>
+/// <param name="ProductionTime">The Production Time of the Record's Label.</param>
+public partial class ScanRecord(Process RecordProcess, Part RecordPart, string Quantity, string JBKNumber, string LotNumber, string DeburrJBKNumber, string DieNumber, string ModelNumber, string HeatNumber, string RecordDate, string RecordTime, string RecordShift, string OperatorID, string ScanAddress, string ProductionDate, string ProductionTime): DataRecord(RecordProcess, RecordPart, Quantity, JBKNumber, LotNumber, DeburrJBKNumber, DieNumber, ModelNumber, HeatNumber, RecordDate, RecordTime, RecordShift, OperatorID, ScanAddress, ProductionDate, ProductionTime) 
 {
     /// <summary>
     /// Converts a DataRecord base class type object into a ScanRecord object (explicit cast).
@@ -31,6 +33,6 @@ public partial class ScanRecord(Process RecordProcess, Part RecordPart, string Q
         {
             throw new ArgumentException($"Cannot convert base DataRecord into a ScanRecord without a non-null 'ScanAddress' property value.");
         }
-        return new ScanRecord(BaseRecord.RecordProcess, BaseRecord.RecordPart, BaseRecord.Quantity, BaseRecord.JBKNumber, BaseRecord.LotNumber, BaseRecord.DeburrJBKNumber, BaseRecord.DieNumber, BaseRecord.ModelNumber, BaseRecord.HeatNumber, BaseRecord.RecordDate, BaseRecord.RecordTime, BaseRecord.RecordShift, BaseRecord.OperatorID, BaseRecord.ScanAddress);
+        return new ScanRecord(BaseRecord.RecordProcess, BaseRecord.RecordPart, BaseRecord.Quantity, BaseRecord.JBKNumber, BaseRecord.LotNumber, BaseRecord.DeburrJBKNumber, BaseRecord.DieNumber, BaseRecord.ModelNumber, BaseRecord.HeatNumber, BaseRecord.RecordDate, BaseRecord.RecordTime, BaseRecord.RecordShift, BaseRecord.OperatorID, BaseRecord.ScanAddress, BaseRecord.ProductionDate!, BaseRecord.ProductionTime!);
     }
 }

--- a/LotCoMClient/Models/Options/DataTablePageOptions.cs
+++ b/LotCoMClient/Models/Options/DataTablePageOptions.cs
@@ -42,12 +42,6 @@ public partial class DataTablePageOptions() : ObservableObject()
     public partial bool IsBodyNavigationPanelShown {get; set;} = false;
 
     /// <summary>
-    /// Controls the number of DataRecords loaded by the Page's DataTable.
-    /// </summary>
-    [ObservableProperty]
-    public partial int TotalRecordCount {get; set;} = 0;
-
-    /// <summary>
     /// Controls the Number of the currently displayed Page of DataRecords, controlled by the Page's Navigation Panel.
     /// </summary>
     [ObservableProperty]
@@ -181,4 +175,32 @@ public partial class DataTablePageOptions() : ObservableObject()
     /// </summary>
     [ObservableProperty]
     public partial bool IsProcessAssigned {get; set;} = false;
+
+    /// <summary>
+    /// Updates the Options object to use the Page's Body Header Label as the Body Header.
+    /// </summary>
+    /// <remarks>
+    /// Optionally accepts HeaderLabelText which will set the Label's text.
+    /// </remarks>
+    /// <param name="HeaderLabelText"></param>
+    public void SetBodyHeaderModeToLabel(string HeaderLabelText = "")
+    {
+        IsBodyHeaderLabelShown = true;
+        IsBodyNavigationPanelShown = false;
+        BodyTableHeaderText = HeaderLabelText;
+    }
+
+    /// <summary>
+    /// Updates the Options object to use the Page's Navigation Panel as the Body Header.
+    /// </summary>
+    /// <remarks>
+    /// Optionally accepts JumpToPageNumber which will set the current Page Number.
+    /// </remarks>
+    /// <param name="JumpToPageNumber"></param>
+    public void SetBodyHeaderModeToNavigation(int JumpToPageNumber = 1)
+    {
+        IsBodyHeaderLabelShown = false;
+        IsBodyNavigationPanelShown = true;
+        PageNumber = JumpToPageNumber;
+    }
 }

--- a/LotCoMClient/Models/Options/DataTablePageOptions.cs
+++ b/LotCoMClient/Models/Options/DataTablePageOptions.cs
@@ -33,7 +33,7 @@ public partial class DataTablePageOptions() : ObservableObject()
     /// Controls the text of the Page's Body Table Header.
     /// </summary>
     [ObservableProperty]
-    public partial string BodyTableHeaderText {get; set;} = "";
+    public partial string BodyHeaderText {get; set;} = "";
 
     /// <summary>
     /// Controls the visibility of the Page's Navigation Panel which is between the Page's Title and Body (ListView).
@@ -48,16 +48,16 @@ public partial class DataTablePageOptions() : ObservableObject()
     public partial int PageNumber {get; set;} = 0;
 
     /// <summary>
-    /// Controls the currently selected index of the Page's ShownRecordCount Picker.
+    /// Controls the currently selected index of the Page's PageLength Picker.
     /// </summary>
     [ObservableProperty]
-    public partial int SelectedShownRecordCountIndex {get; set;} = 1;
+    public partial int SelectedPageLengthIndex {get; set;} = 1;
 
     /// <summary>
-    /// Controls the number of DataRecords displayed by the Page's ListView, controlled by the Page's Navigation Panel.
+    /// Controls the number of DataRecords displayed by each Page of the DataTablePage's ListView, controlled by the Page's Navigation Panel.
     /// </summary>
     [ObservableProperty]
-    public partial int ShownRecordCount {get; set;} = 25;
+    public partial int PageLength {get; set;} = 25;
 
     /// <summary>
     /// Controls the text shown in the Page's Left Panel Header which appears at the top of the collapsable Left Panel.
@@ -193,7 +193,7 @@ public partial class DataTablePageOptions() : ObservableObject()
     {
         IsBodyHeaderLabelShown = true;
         IsBodyNavigationPanelShown = false;
-        BodyTableHeaderText = HeaderLabelText;
+        BodyHeaderText = HeaderLabelText;
     }
 
     /// <summary>

--- a/LotCoMClient/Models/Options/DataTablePageOptions.cs
+++ b/LotCoMClient/Models/Options/DataTablePageOptions.cs
@@ -26,7 +26,7 @@ public partial class DataTablePageOptions() : ObservableObject()
         public const bool IsBodyHeaderLabelShown = false;
         public const string BodyHeaderText = "";
         public const bool IsBodyNavigationPanelShown = false;
-        public const int PageNumber = 0;
+        public const int PageNumber = 1;
         public const int SelectedPageLengthIndex = 1;
         public const int PageLength = 25;
         public const string LeftPanelHeaderText = "";
@@ -70,6 +70,7 @@ public partial class DataTablePageOptions() : ObservableObject()
 
     /// <summary>
     /// Controls the Number of the currently displayed Page of DataRecords, controlled by the Page's Navigation Panel.
+    /// This value is 1-oriented, so Page 1 will refer to index 0 of a PageSet.Pages List.
     /// </summary>
     [ObservableProperty]
     public partial int PageNumber {get; set;} = OptionDefaults.PageNumber;

--- a/LotCoMClient/Models/Options/DataTablePageOptions.cs
+++ b/LotCoMClient/Models/Options/DataTablePageOptions.cs
@@ -18,76 +18,103 @@ public partial class DataTablePageOptions() : ObservableObject()
     }
 
     /// <summary>
+    /// Provides default values for most Options.
+    /// </summary>
+    public static class OptionDefaults
+    {
+        public const string Title = "";
+        public const bool IsBodyHeaderLabelShown = false;
+        public const string BodyHeaderText = "";
+        public const bool IsBodyNavigationPanelShown = false;
+        public const int PageNumber = 0;
+        public const int SelectedPageLengthIndex = 1;
+        public const int PageLength = 25;
+        public const string LeftPanelHeaderText = "";
+        public const string LeftPanelFooterText = "Click to Collapse";
+        public const bool IsLeftPanelShown = true;
+        public const bool IsLeftPanelHidden = false;
+        public const int LeftPanelWidth = (int)LeftPanelWidths.Open;
+        public const int SelectedSortingFieldIndex = -1;
+        public const int SelectedSortingOrderIndex = 1;
+        public const int SelectedSearchingFieldIndex = 0;
+        public const string SearchTerm = "";
+        public const Department? Department = null;
+        public const Process? Process = null;
+        public const int SelectedProcessIndex = -1;
+        public const bool IsProcessAssigned = false;
+    }
+
+    /// <summary>
     /// Controls the Page's Title which appears in the top-left corner.
     /// </summary>
     [ObservableProperty]
-    public partial string Title {get; set;} = "";
+    public partial string Title {get; set;} = OptionDefaults.Title;
 
     /// <summary>
     /// Controls the visibility of the Page's Body Header which is between the Page's Title and Body (ListView).
     /// </summary>
     [ObservableProperty]
-    public partial bool IsBodyHeaderLabelShown {get; set;} = false;
+    public partial bool IsBodyHeaderLabelShown {get; set;} = OptionDefaults.IsBodyHeaderLabelShown;
 
     /// <summary>
     /// Controls the text of the Page's Body Table Header.
     /// </summary>
     [ObservableProperty]
-    public partial string BodyHeaderText {get; set;} = "";
+    public partial string BodyHeaderText {get; set;} = OptionDefaults.BodyHeaderText;
 
     /// <summary>
     /// Controls the visibility of the Page's Navigation Panel which is between the Page's Title and Body (ListView).
     /// </summary>
     [ObservableProperty]
-    public partial bool IsBodyNavigationPanelShown {get; set;} = false;
+    public partial bool IsBodyNavigationPanelShown {get; set;} = OptionDefaults.IsBodyNavigationPanelShown;
 
     /// <summary>
     /// Controls the Number of the currently displayed Page of DataRecords, controlled by the Page's Navigation Panel.
     /// </summary>
     [ObservableProperty]
-    public partial int PageNumber {get; set;} = 0;
+    public partial int PageNumber {get; set;} = OptionDefaults.PageNumber;
 
     /// <summary>
     /// Controls the currently selected index of the Page's PageLength Picker.
     /// </summary>
     [ObservableProperty]
-    public partial int SelectedPageLengthIndex {get; set;} = 1;
+    public partial int SelectedPageLengthIndex {get; set;} = OptionDefaults.SelectedPageLengthIndex;
 
     /// <summary>
     /// Controls the number of DataRecords displayed by each Page of the DataTablePage's ListView, controlled by the Page's Navigation Panel.
     /// </summary>
     [ObservableProperty]
-    public partial int PageLength {get; set;} = 25;
+    public partial int PageLength {get; set;} = OptionDefaults.PageLength;
 
     /// <summary>
     /// Controls the text shown in the Page's Left Panel Header which appears at the top of the collapsable Left Panel.
     /// </summary>
     [ObservableProperty]
-    public partial string LeftPanelHeaderText {get; set;} = "";
+    public partial string LeftPanelHeaderText {get; set;} = OptionDefaults.LeftPanelHeaderText;
 
     /// <summary>
     /// Controls the text shown in the Page's Left Panel Footer which appears at the bottom of the collapsable Left Panel.
     /// </summary>
     [ObservableProperty]
-    public partial string LeftPanelFooterText {get; set;} = "Click to Collapse";
+    public partial string LeftPanelFooterText {get; set;} = OptionDefaults.LeftPanelFooterText;
 
     /// <summary>
     /// Controls the Page's Left Panel Shown state (boolean).
     /// </summary>
     [ObservableProperty]
-    public partial bool IsLeftPanelShown {get; set;} = true;
+    public partial bool IsLeftPanelShown {get; set;} = OptionDefaults.IsLeftPanelShown;
 
     /// <summary>
     /// Controls the Page's Left Panel Hidden state (boolean).
     /// </summary>
     [ObservableProperty]
-    public partial bool IsLeftPanelHidden {get; set;} = false;
+    public partial bool IsLeftPanelHidden {get; set;} = OptionDefaults.IsLeftPanelHidden;
 
     /// <summary>
     /// Controls the width of the Page's Left Panel.
     /// </summary>
     [ObservableProperty]
-    public partial int LeftPanelWidth {get; set;} = (int)LeftPanelWidths.Open;
+    public partial int LeftPanelWidth {get; set;} = OptionDefaults.LeftPanelWidth;
     
     /// <summary>
     /// Controls the data fields that are included in DataRecords for the Page's ListView.
@@ -124,31 +151,31 @@ public partial class DataTablePageOptions() : ObservableObject()
     /// Controls the currently selected index of the Page's SortingField Picker.
     /// </summary>
     [ObservableProperty]
-    public partial int SelectedSortingFieldIndex {get; set;} = -1;
+    public partial int SelectedSortingFieldIndex {get; set;} = OptionDefaults.SelectedSortingFieldIndex;
 
     /// <summary>
     /// Controls the currently selected index of the Page's SortingOrder Picker.
     /// </summary>
     [ObservableProperty]
-    public partial int SelectedSortingOrderIndex {get; set;} = -1;
+    public partial int SelectedSortingOrderIndex {get; set;} = OptionDefaults.SelectedSortingOrderIndex;
 
     /// <summary>
     /// Controls the currently selected index of the Page's SearchingField Picker.
     /// </summary>
     [ObservableProperty]
-    public partial int SelectedSearchingFieldIndex {get; set;} = -1;
+    public partial int SelectedSearchingFieldIndex {get; set;} = OptionDefaults.SelectedSearchingFieldIndex;
 
     /// <summary>
     /// Controls the currently entered Text value of the Page's ListViewSearchBar.
     /// </summary>
     [ObservableProperty]
-    public partial string SearchTerm {get; set;} = "";
+    public partial string SearchTerm {get; set;} = OptionDefaults.SearchTerm;
 
     /// <summary>
     /// Controls the Department that defines the Process currently shown on the Page.
     /// </summary>
     [ObservableProperty]
-    public partial Department? Department {get; set;} = null;
+    public partial Department? Department {get; set;} = OptionDefaults.Department;
 
     /// <summary>
     /// For Selector Pages;
@@ -161,14 +188,14 @@ public partial class DataTablePageOptions() : ObservableObject()
     /// Controls the Process that defines the Parts and Data currently shown on the Page.
     /// </summary>
     [ObservableProperty]
-    public partial Process? Process {get; set;} = null;
+    public partial Process? Process {get; set;} = OptionDefaults.Process;
 
     /// <summary>
     /// For Selector Pages;
     /// Controls the currently selected index of the Page's PageProcess Picker.
     /// </summary>
     [ObservableProperty]
-    public partial int SelectedProcessIndex {get; set;} = -1;
+    public partial int SelectedProcessIndex {get; set;} = OptionDefaults.SelectedProcessIndex;
 
     /// <summary>
     /// Controls the subclass of DataRecord displayed by the Page's ListView.
@@ -180,7 +207,7 @@ public partial class DataTablePageOptions() : ObservableObject()
     /// Controls the boolean condition of whether a Process has been assigned to the Page.
     /// </summary>
     [ObservableProperty]
-    public partial bool IsProcessAssigned {get; set;} = false;
+    public partial bool IsProcessAssigned {get; set;} = OptionDefaults.IsProcessAssigned;
 
     /// <summary>
     /// Updates the Options object to use the Page's Body Header Label as the Body Header.

--- a/LotCoMClient/Models/Options/DataTablePageOptions.cs
+++ b/LotCoMClient/Models/Options/DataTablePageOptions.cs
@@ -17,82 +17,88 @@ public partial class DataTablePageOptions() : ObservableObject()
         Open = 250
     }
 
-    [ObservableProperty]
     /// <summary>
     /// Controls the Page's Title which appears in the top-left corner.
     /// </summary>
+    [ObservableProperty]
     public partial string Title {get; set;} = "";
 
-    [ObservableProperty]
     /// <summary>
     /// Controls the visibility of the Page's Body Header which is between the Page's Title and Body (ListView).
     /// </summary>
+    [ObservableProperty]
     public partial bool IsBodyHeaderLabelShown {get; set;} = false;
 
-    [ObservableProperty]
     /// <summary>
     /// Controls the text of the Page's Body Table Header.
     /// </summary>
+    [ObservableProperty]
     public partial string BodyTableHeaderText {get; set;} = "";
 
-    [ObservableProperty]
     /// <summary>
     /// Controls the visibility of the Page's Navigation Panel which is between the Page's Title and Body (ListView).
     /// </summary>
+    [ObservableProperty]
     public partial bool IsBodyNavigationPanelShown {get; set;} = false;
 
-    [ObservableProperty]
     /// <summary>
     /// Controls the number of DataRecords loaded by the Page's DataTable.
     /// </summary>
+    [ObservableProperty]
     public partial int TotalRecordCount {get; set;} = 0;
 
-    [ObservableProperty]
     /// <summary>
     /// Controls the Number of the currently displayed Page of DataRecords, controlled by the Page's Navigation Panel.
     /// </summary>
+    [ObservableProperty]
     public partial int PageNumber {get; set;} = 0;
 
+    /// <summary>
+    /// Controls the currently selected index of the Page's ShownRecordCount Picker.
+    /// </summary>
     [ObservableProperty]
+    public partial int SelectedShownRecordCountIndex {get; set;} = 1;
+
     /// <summary>
     /// Controls the number of DataRecords displayed by the Page's ListView, controlled by the Page's Navigation Panel.
     /// </summary>
-    public partial int DisplayedRecordCount {get; set;} = 0;
-
     [ObservableProperty]
+    public partial int ShownRecordCount {get; set;} = 25;
+
     /// <summary>
     /// Controls the text shown in the Page's Left Panel Header which appears at the top of the collapsable Left Panel.
     /// </summary>
+    [ObservableProperty]
     public partial string LeftPanelHeaderText {get; set;} = "";
 
-    [ObservableProperty]
     /// <summary>
     /// Controls the text shown in the Page's Left Panel Footer which appears at the bottom of the collapsable Left Panel.
     /// </summary>
+    [ObservableProperty]
     public partial string LeftPanelFooterText {get; set;} = "Click to Collapse";
 
-    [ObservableProperty]
     /// <summary>
     /// Controls the Page's Left Panel Shown state (boolean).
     /// </summary>
+    [ObservableProperty]
     public partial bool IsLeftPanelShown {get; set;} = true;
 
-    [ObservableProperty]
     /// <summary>
     /// Controls the Page's Left Panel Hidden state (boolean).
     /// </summary>
+    [ObservableProperty]
     public partial bool IsLeftPanelHidden {get; set;} = false;
 
-    [ObservableProperty]
     /// <summary>
     /// Controls the width of the Page's Left Panel.
     /// </summary>
+    [ObservableProperty]
     public partial int LeftPanelWidth {get; set;} = (int)LeftPanelWidths.Open;
     
-    [ObservableProperty]
     /// <summary>
     /// Controls the data fields that are included in DataRecords for the Page's ListView.
     /// </summary>
+    [ObservableProperty]
     public partial List<string> DataFields {get; set;} = 
     [
         "Part Number", 
@@ -104,10 +110,10 @@ public partial class DataTablePageOptions() : ObservableObject()
         "Operator ID"
     ];
 
-    [ObservableProperty]
     /// <summary>
     /// Controls the fields that can be used to search the Page's ListView.
     /// </summary>
+    [ObservableProperty]
     public partial List<string> SearchableFields {get; set;} = 
     [
         "All", 
@@ -120,59 +126,59 @@ public partial class DataTablePageOptions() : ObservableObject()
         "Operator ID"
     ];
 
-    [ObservableProperty]
     /// <summary>
     /// Controls the currently selected index of the Page's SortingField Picker.
     /// </summary>
+    [ObservableProperty]
     public partial int SelectedSortingFieldIndex {get; set;} = -1;
 
-    [ObservableProperty]
     /// <summary>
     /// Controls the currently selected index of the Page's SortingOrder Picker.
     /// </summary>
+    [ObservableProperty]
     public partial int SelectedSortingOrderIndex {get; set;} = -1;
 
-    [ObservableProperty]
     /// <summary>
     /// Controls the currently selected index of the Page's SearchingField Picker.
     /// </summary>
+    [ObservableProperty]
     public partial int SelectedSearchingFieldIndex {get; set;} = -1;
 
-    [ObservableProperty]
     /// <summary>
     /// Controls the currently entered Text value of the Page's ListViewSearchBar.
     /// </summary>
+    [ObservableProperty]
     public partial string SearchTerm {get; set;} = "";
 
-    [ObservableProperty]
     /// <summary>
     /// Controls the Department that defines the Process currently shown on the Page.
     /// </summary>
+    [ObservableProperty]
     public partial Department? Department {get; set;} = null;
 
-    [ObservableProperty]
     /// <summary>
     /// For Selector Pages;
     /// Controls the Processes that are selectable in the Page's PageProcess Picker.
     /// </summary>
+    [ObservableProperty]
     public partial List<Process> DepartmentProcesses {get; set;} = [];
 
-    [ObservableProperty]
     /// <summary>
     /// For Selector Pages;
     /// Controls the currently selected index of the Page's PageProcess Picker.
     /// </summary>
+    [ObservableProperty]
     public partial int SelectedProcessIndex {get; set;} = -1;
 
-    [ObservableProperty]
     /// <summary>
     /// Controls the subclass of DataRecord displayed by the Page's ListView.
     /// </summary>
+    [ObservableProperty]
     public partial Type RecordType {get; set;} = typeof(DataRecord);
 
-    [ObservableProperty]
     /// <summary>
     /// Controls the boolean condition of whether a Process has been assigned to the Page.
     /// </summary>
+    [ObservableProperty]
     public partial bool IsProcessAssigned {get; set;} = false;
 }

--- a/LotCoMClient/Models/Options/DataTablePageOptions.cs
+++ b/LotCoMClient/Models/Options/DataTablePageOptions.cs
@@ -158,6 +158,12 @@ public partial class DataTablePageOptions() : ObservableObject()
     public partial List<Process> DepartmentProcesses {get; set;} = [];
 
     /// <summary>
+    /// Controls the Process that defines the Parts and Data currently shown on the Page.
+    /// </summary>
+    [ObservableProperty]
+    public partial Process? Process {get; set;} = null;
+
+    /// <summary>
     /// For Selector Pages;
     /// Controls the currently selected index of the Page's PageProcess Picker.
     /// </summary>

--- a/LotCoMClient/Models/Options/DataTablePageOptions.cs
+++ b/LotCoMClient/Models/Options/DataTablePageOptions.cs
@@ -209,4 +209,61 @@ public partial class DataTablePageOptions() : ObservableObject()
         IsBodyNavigationPanelShown = true;
         PageNumber = JumpToPageNumber;
     }
+
+    /// <summary>
+    /// Updates the Options object's DataFields and SearchableFields properties to provide the Page's Process Requirements.
+    /// </summary>
+    /// <returns></returns>
+    public async Task ConfigurePageFields() 
+    {
+        await Task.Run(() => 
+        {
+            // start with the universally included fields
+            List<string> Fields = 
+            [
+                "Part Number", 
+                "Part Name", 
+                "Quantity", 
+                "Production Date", 
+                "Production Time", 
+                "Production Shift", 
+                "Operator ID"
+            ];
+            if (Process is null)
+            {
+                return;
+            }
+            // add the variably-required DataRecord fields from the Page Process requirements
+            List<string> Requirements = Process.RequiredFields;
+            if (Requirements.Contains("JBKNumber")) 
+            {
+                Fields.Add("JBK Number");
+            }
+            if (Requirements.Contains("LotNumber")) 
+            {
+                Fields.Add("Lot Number");
+            }
+            if (Requirements.Contains("DeburrJBKNumber")) 
+            {
+                Fields.Add("Deburr JBK Number");
+            }
+            if (Requirements.Contains("DieNumber")) 
+            {
+                Fields.Add("Die Number");
+            }
+            if (Requirements.Contains("ModelNumber")) 
+            {
+                Fields.Add("Model Number");
+            }
+            if (Requirements.Contains("HeatNumber")) 
+            {
+                Fields.Add("Heat Number");
+            }
+            // update the DataFields and SearchableFields properties
+            DataFields = Fields;
+            SearchableFields = Fields
+                .Prepend("All")
+                .ToList();
+        });
+    }
 }

--- a/LotCoMClient/Models/Options/DataTablePageOptions.cs
+++ b/LotCoMClient/Models/Options/DataTablePageOptions.cs
@@ -11,7 +11,8 @@ public partial class DataTablePageOptions() : ObservableObject()
     /// <summary>
     /// Provides default Left Panel widths for Open and Closed states.
     /// </summary>
-    public enum LeftPanelWidths {
+    public enum LeftPanelWidths 
+    {
         Closed = 30,
         Open = 250
     }
@@ -24,9 +25,39 @@ public partial class DataTablePageOptions() : ObservableObject()
 
     [ObservableProperty]
     /// <summary>
+    /// Controls the visibility of the Page's Body Header which is between the Page's Title and Body (ListView).
+    /// </summary>
+    public partial bool IsBodyHeaderLabelShown {get; set;} = false;
+
+    [ObservableProperty]
+    /// <summary>
     /// Controls the text of the Page's Body Table Header.
     /// </summary>
     public partial string BodyTableHeaderText {get; set;} = "";
+
+    [ObservableProperty]
+    /// <summary>
+    /// Controls the visibility of the Page's Navigation Panel which is between the Page's Title and Body (ListView).
+    /// </summary>
+    public partial bool IsBodyNavigationPanelShown {get; set;} = false;
+
+    [ObservableProperty]
+    /// <summary>
+    /// Controls the number of DataRecords loaded by the Page's DataTable.
+    /// </summary>
+    public partial int TotalRecordCount {get; set;} = 0;
+
+    [ObservableProperty]
+    /// <summary>
+    /// Controls the Number of the currently displayed Page of DataRecords, controlled by the Page's Navigation Panel.
+    /// </summary>
+    public partial int PageNumber {get; set;} = 0;
+
+    [ObservableProperty]
+    /// <summary>
+    /// Controls the number of DataRecords displayed by the Page's ListView, controlled by the Page's Navigation Panel.
+    /// </summary>
+    public partial int DisplayedRecordCount {get; set;} = 0;
 
     [ObservableProperty]
     /// <summary>

--- a/LotCoMClient/Models/Options/DataTablePageOptions.cs
+++ b/LotCoMClient/Models/Options/DataTablePageOptions.cs
@@ -266,4 +266,26 @@ public partial class DataTablePageOptions() : ObservableObject()
                 .ToList();
         });
     }
+
+    /// <summary>
+    /// Configures the Options object's properties to raise and show the Page's Left Panel.
+    /// </summary>
+    public void RaiseLeftPanel()
+    {
+        // set the Left Panel properties
+        IsLeftPanelShown = false;
+        IsLeftPanelHidden = true;
+        LeftPanelWidth = (int)LeftPanelWidths.Closed;
+    }
+
+    /// <summary>
+    /// Configures the Options object's properties to collapse and hide the Page's Left Panel.
+    /// </summary>
+    public void CollapseLeftPanel() 
+    {
+        // set the Left Panel properties
+    IsLeftPanelShown = true;
+    IsLeftPanelHidden = false;
+    LeftPanelWidth = (int)LeftPanelWidths.Open;
+    }
 }

--- a/LotCoMClient/ViewModels/DataTableSelectorViewModel.cs
+++ b/LotCoMClient/ViewModels/DataTableSelectorViewModel.cs
@@ -72,7 +72,7 @@ public partial class DataTableSelectorViewModel : DataTableViewModel
         // update the Page's DataTable to consume data from the newly selected Process Database Table
         Table = new DataTable($"{FullPath}\\{SelectedProcess.FullName}.txt");
         // update the Page's Data
-        Data = new NotifyTaskCompletion<List<DataRecord>>(Table.RequestRecords());
+        SetNewPage(new NotifyTaskCompletion<Models.Datasources.Page>(Table.RequestPage(0, Options.ShownRecordCount)));
         Options.IsProcessAssigned = true;
     }
 }

--- a/LotCoMClient/ViewModels/DataTableSelectorViewModel.cs
+++ b/LotCoMClient/ViewModels/DataTableSelectorViewModel.cs
@@ -72,7 +72,7 @@ public partial class DataTableSelectorViewModel : DataTableViewModel
         // update the Page's DataTable to consume data from the newly selected Process Database Table
         Table = new DataTable($"{FullPath}\\{SelectedProcess.FullName}.txt");
         // update the Page's Data
-        SetNewPage(new NotifyTaskCompletion<Models.Datasources.Page>(Table.RequestPage(0, Options.ShownRecordCount)));
+        SetNewPage(new NotifyTaskCompletion<Models.Datasources.Page>(Table.RequestPage(0, Options.PageLength)));
         Options.IsProcessAssigned = true;
     }
 }

--- a/LotCoMClient/ViewModels/DataTableViewModel.cs
+++ b/LotCoMClient/ViewModels/DataTableViewModel.cs
@@ -26,11 +26,11 @@ public partial class DataTableViewModel : ObservableObject
         }
     }
 
-    private NotifyTaskCompletion<List<DataRecord>>? _data;
+    private NotifyTaskCompletion<Models.Datasources.Page>? _data;
     /// <summary>
     /// Serves the Data in the Page's assigned Database Table.
     /// </summary>
-    public NotifyTaskCompletion<List<DataRecord>>? Data 
+    public NotifyTaskCompletion<Models.Datasources.Page>? Data 
     {
         get {return _data;}
         set 
@@ -110,7 +110,7 @@ public partial class DataTableViewModel : ObservableObject
         {
             // create a DataTable from the path passed in DataTablePath
             Table = new DataTable(DataTablePath);
-            Data = new NotifyTaskCompletion<List<DataRecord>>(Table.ReadRecordsAsync());
+            Data = new NotifyTaskCompletion<Models.Datasources.Page>(Table.RequestPage(0, Options.ShownRecordCount));
             Options.Process = Table.Process;
             Options.LeftPanelHeaderText = Table.Process!.FullName;
             Options.SetBodyHeaderModeToLabel("Loading records...");
@@ -135,7 +135,7 @@ public partial class DataTableViewModel : ObservableObject
         string SortField = Options.DataFields[Options.SelectedSortingFieldIndex];
         SortField = ResolveDataRecordPropertyName(SortField);
         // sort using the Model class
-        Data = new NotifyTaskCompletion<List<DataRecord>>(Table!.RequestSort(SortField, Options.SelectedSortingOrderIndex));
+        Data = new NotifyTaskCompletion<Models.Datasources.Page>(Table!.RequestSort(SortField, Options.SelectedSortingOrderIndex));
     }
 
     /// <summary>
@@ -152,6 +152,6 @@ public partial class DataTableViewModel : ObservableObject
             PropertyName = ResolveDataRecordPropertyName(PropertyName);
         }
         // Search using the Model class
-        Data = new NotifyTaskCompletion<List<DataRecord>>(Table!.RequestSearch(Options.SearchTerm, PropertyName));
+        Data = new NotifyTaskCompletion<Models.Datasources.Page>(Table!.RequestSearch(Options.SearchTerm, PropertyName));
     }
 }

--- a/LotCoMClient/ViewModels/DataTableViewModel.cs
+++ b/LotCoMClient/ViewModels/DataTableViewModel.cs
@@ -216,7 +216,7 @@ public partial class DataTableViewModel : ObservableObject
     /// </summary>
     public async Task GoToNextPage()
     {
-        await Table!.GoToLastPage();
+        await Table!.GoToNextPage();
         // update the DataTablePage to show the new Active Page of the PageSet
         SetNewPage(new NotifyTaskCompletion<Models.Datasources.Page>(Table!.ActivePageSet.GetActivePage()));
     }

--- a/LotCoMClient/ViewModels/DataTableViewModel.cs
+++ b/LotCoMClient/ViewModels/DataTableViewModel.cs
@@ -2,6 +2,7 @@ using CommunityToolkit.Mvvm.ComponentModel;
 using LotCoMClient.Models.Datasources;
 using LotCoMClient.Models.Options;
 using LotCoMClient.Models.Services;
+using System.Linq.Dynamic;
 
 namespace LotCoMClient.ViewModels;
 
@@ -118,6 +119,38 @@ public partial class DataTableViewModel : ObservableObject
     }
 
     /// <summary>
+    /// Performs an in-place sort of the DataRecords property of CurrentPage.
+    /// </summary>
+    /// <param name="SortingProperty"></param>
+    /// <param name="SortOrder"></param>
+    /// <returns></returns>
+    /// <exception cref="OperationCanceledException"></exception>
+    private async Task<NotifyTaskCompletion<Models.Datasources.Page>> SortCurrentPage(string SortingProperty, int SortOrder)
+    {
+        // confirm that the CurrentPage is available for operations
+        if (CurrentPage is null 
+            || CurrentPage.IsNotCompleted 
+            || CurrentPage.Result is null)
+        {
+            throw new OperationCanceledException();
+        }
+        return await Task.Run(() => 
+        {
+            // use LINQ dynamic to sort using the property selected in the sorting field picker
+            CurrentPage.Result.DataRecords = CurrentPage.Result.DataRecords
+                .AsQueryable()
+                .OrderBy(SortingProperty)
+                .ToList();
+            // invert the order (ascending by default) if descending sort was selected
+            if (SortOrder == 1) 
+            {
+                CurrentPage.Result.DataRecords.Reverse();
+            }
+            return CurrentPage;
+        });
+    }
+
+    /// <summary>
     /// Creates a ViewModel for the DataTablePage.
     /// </summary>
     /// <param name="DataTablePath">The desired display Database Table's full path.</param>
@@ -149,16 +182,16 @@ public partial class DataTableViewModel : ObservableObject
     }
 
     /// <summary>
-    /// Sorts the DataRecords in the Data property using the Sorting Field and orders it according to the Order selection.
+    /// Sorts the DataRecords in the CurrentPage property using the Sorting Field and orders it according to the Order selection.
     /// </summary>
     /// <returns></returns>
-    public void SortDataTable()
+    public async Task SortPage()
     {
         // get the selected Field from the Sorting Field Picker
         string SortField = Options.DataFields[Options.SelectedSortingFieldIndex];
         SortField = ResolveDataRecordPropertyName(SortField);
         // sort using the Model class
-        Data = new NotifyTaskCompletion<Models.Datasources.Page>(Table!.RequestSort(SortField, Options.SelectedSortingOrderIndex));
+        CurrentPage = await SortCurrentPage(SortField, Options.SelectedSortingOrderIndex);
     }
 
     /// <summary>

--- a/LotCoMClient/ViewModels/DataTableViewModel.cs
+++ b/LotCoMClient/ViewModels/DataTableViewModel.cs
@@ -111,8 +111,8 @@ public partial class DataTableViewModel : ObservableObject
             // create a DataTable from the path passed in DataTablePath
             Table = new DataTable(DataTablePath);
             Data = new NotifyTaskCompletion<List<DataRecord>>(Table.ReadRecordsAsync());
-            Options.Process = new ProcessData().GetIndividualProcess(Table.TableProcess);
-            Options.LeftPanelHeaderText = Table!.TableProcess;
+            Options.Process = Table.Process;
+            Options.LeftPanelHeaderText = Table.Process!.FullName;
             Options.SetBodyHeaderModeToLabel("Loading records...");
         // no Process is assigned at instantiation
         } 
@@ -143,10 +143,12 @@ public partial class DataTableViewModel : ObservableObject
     /// Configures the Data property to only show those match hits.
     /// </summary>
     /// <returns></returns>
-    public void SearchDataTable() {
+    public void SearchDataTable() 
+    {
         // get the selected Field from the Searching Field Picker
         string PropertyName = Options.SearchableFields[Options.SelectedSearchingFieldIndex];
-        if (PropertyName != "All") {
+        if (PropertyName != "All") 
+        {
             PropertyName = ResolveDataRecordPropertyName(PropertyName);
         }
         // Search using the Model class

--- a/LotCoMClient/ViewModels/DataTableViewModel.cs
+++ b/LotCoMClient/ViewModels/DataTableViewModel.cs
@@ -172,6 +172,17 @@ public partial class DataTableViewModel : ObservableObject
     }
 
     /// <summary>
+    /// Clears the Sorting and Searching options and resets them to the default values.
+    /// </summary>
+    public void ClearFilterOptions()
+    {
+        Options.SelectedSortingFieldIndex = DataTablePageOptions.OptionDefaults.SelectedSortingFieldIndex;
+        Options.SelectedSortingOrderIndex = DataTablePageOptions.OptionDefaults.SelectedSortingOrderIndex;
+        Options.SearchTerm = DataTablePageOptions.OptionDefaults.SearchTerm;
+        Options.SelectedSearchingFieldIndex = DataTablePageOptions.OptionDefaults.SelectedSearchingFieldIndex;
+    }
+
+    /// <summary>
     /// Sets the BasePage and CurrentPage properties to NewPage, resetting the Page's shown DataRecord Page.
     /// </summary>
     /// <param name="NewPage"></param>
@@ -240,6 +251,10 @@ public partial class DataTableViewModel : ObservableObject
     public async Task SortPage()
     {
         // get the selected Field from the Sorting Field Picker
+        if (Options.SelectedSortingFieldIndex == -1 || Options.SelectedSortingOrderIndex == -1)
+        {
+            return;
+        }
         string SortField = Options.DataFields[Options.SelectedSortingFieldIndex];
         SortField = ResolveDataRecordPropertyName(SortField);
         // sort using the Model class
@@ -254,6 +269,10 @@ public partial class DataTableViewModel : ObservableObject
     public void SearchDataTable() 
     {
         // get the selected Field from the Searching Field Picker
+        if (Options.SelectedSearchingFieldIndex == -1)
+        {
+            return;
+        }
         string PropertyName = Options.SearchableFields[Options.SelectedSearchingFieldIndex];
         if (PropertyName != "All") 
         {

--- a/LotCoMClient/ViewModels/DataTableViewModel.cs
+++ b/LotCoMClient/ViewModels/DataTableViewModel.cs
@@ -159,7 +159,7 @@ public partial class DataTableViewModel : ObservableObject
             // create a DataTable from the path passed in DataTablePath
             Table = new DataTable(DataTablePath);
             // display the first Page in the DataTable with the default PageLength
-            SetNewPage(new NotifyTaskCompletion<Models.Datasources.Page>(Table.RequestPage(0, Options.ShownRecordCount)));
+            SetNewPage(new NotifyTaskCompletion<Models.Datasources.Page>(Table.RequestPage(0, Options.PageLength)));
             Options.Process = Table.Process;
             Options.LeftPanelHeaderText = Table.Process!.FullName;
             Options.SetBodyHeaderModeToLabel("Loading records...");
@@ -248,6 +248,6 @@ public partial class DataTableViewModel : ObservableObject
             PropertyName = ResolveDataRecordPropertyName(PropertyName);
         }
         // Search using the Model class
-        CurrentPage = new NotifyTaskCompletion<Models.Datasources.Page>(Table!.SearchAsync(Options.SearchTerm, PropertyName, Options.ShownRecordCount));
+        CurrentPage = new NotifyTaskCompletion<Models.Datasources.Page>(Table!.SearchAsync(Options.SearchTerm, PropertyName, Options.PageLength));
     }
 }

--- a/LotCoMClient/ViewModels/DataTableViewModel.cs
+++ b/LotCoMClient/ViewModels/DataTableViewModel.cs
@@ -73,6 +73,21 @@ public partial class DataTableViewModel : ObservableObject
         }
     }
 
+    private string _pageNumberContext = "";
+    /// <summary>
+    /// Provides a formatted string that gives the context of the currently displayed Page Number in the PageSet.
+    /// </summary>
+    public string PageNumberContext
+    {
+        get {return _pageNumberContext;}
+        set
+        {
+            _pageNumberContext = value;
+            OnPropertyChanged(nameof(_pageNumberContext));
+            OnPropertyChanged(nameof(PageNumberContext));
+        }
+    }
+
     /// <summary>
     /// Resolves a defined Property Name on DataRecord from a passed String.
     /// </summary>
@@ -191,6 +206,8 @@ public partial class DataTableViewModel : ObservableObject
     {
         BasePage = NewPage;
         CurrentPage = NewPage;
+        Options.PageNumber = Table!.ActivePageSet.ActivePageIndex + 1;
+        PageNumberContext = $"{Options.PageNumber} of {Table!.ActivePageSet.PageCount}";
     }
 
     /// <summary>

--- a/LotCoMClient/ViewModels/DataTableViewModel.cs
+++ b/LotCoMClient/ViewModels/DataTableViewModel.cs
@@ -109,16 +109,6 @@ public partial class DataTableViewModel : ObservableObject
     }
 
     /// <summary>
-    /// Sets the BasePage and CurrentPage properties to NewPage, resetting the Page's shown DataRecord Page.
-    /// </summary>
-    /// <param name="NewPage"></param>
-    private void SetNewPage(NotifyTaskCompletion<Models.Datasources.Page> NewPage)
-    {
-        BasePage = NewPage;
-        CurrentPage = NewPage;
-    }
-
-    /// <summary>
     /// Performs an in-place sort of the DataRecords property of CurrentPage.
     /// </summary>
     /// <param name="SortingProperty"></param>
@@ -182,6 +172,16 @@ public partial class DataTableViewModel : ObservableObject
     }
 
     /// <summary>
+    /// Sets the BasePage and CurrentPage properties to NewPage, resetting the Page's shown DataRecord Page.
+    /// </summary>
+    /// <param name="NewPage"></param>
+    public void SetNewPage(NotifyTaskCompletion<Models.Datasources.Page> NewPage)
+    {
+        BasePage = NewPage;
+        CurrentPage = NewPage;
+    }
+
+    /// <summary>
     /// Sorts the DataRecords in the CurrentPage property using the Sorting Field and orders it according to the Order selection.
     /// </summary>
     /// <returns></returns>
@@ -208,6 +208,6 @@ public partial class DataTableViewModel : ObservableObject
             PropertyName = ResolveDataRecordPropertyName(PropertyName);
         }
         // Search using the Model class
-        Data = new NotifyTaskCompletion<Models.Datasources.Page>(Table!.RequestSearch(Options.SearchTerm, PropertyName));
+        CurrentPage = new NotifyTaskCompletion<Models.Datasources.Page>(Table!.SearchAsync(Options.SearchTerm, PropertyName, Options.ShownRecordCount));
     }
 }

--- a/LotCoMClient/ViewModels/DataTableViewModel.cs
+++ b/LotCoMClient/ViewModels/DataTableViewModel.cs
@@ -26,18 +26,33 @@ public partial class DataTableViewModel : ObservableObject
         }
     }
 
-    private NotifyTaskCompletion<Models.Datasources.Page>? _data;
+    private NotifyTaskCompletion<Models.Datasources.Page>? _basePage;
     /// <summary>
-    /// Serves the Data in the Page's assigned Database Table.
+    /// An unmodified version of the DataRecord Page currently shown by the DataTablePage.
     /// </summary>
-    public NotifyTaskCompletion<Models.Datasources.Page>? Data 
+    public NotifyTaskCompletion<Models.Datasources.Page>? BasePage 
     {
-        get {return _data;}
+        get {return _basePage;}
         set 
         {
-            _data = value;
-            OnPropertyChanged(nameof(_data));
-            OnPropertyChanged(nameof(Data));
+            _basePage = value;
+            OnPropertyChanged(nameof(_basePage));
+            OnPropertyChanged(nameof(BasePage));
+        }
+    }
+
+    private NotifyTaskCompletion<Models.Datasources.Page>? _currentPage;
+    /// <summary>
+    /// A modifyable version of the DataRecord Page currently shown by the DataTablePage.
+    /// </summary>
+    public NotifyTaskCompletion<Models.Datasources.Page>? CurrentPage 
+    {
+        get {return _currentPage;}
+        set 
+        {
+            _currentPage = value;
+            OnPropertyChanged(nameof(_currentPage));
+            OnPropertyChanged(nameof(CurrentPage));
         }
     }
 
@@ -93,6 +108,16 @@ public partial class DataTableViewModel : ObservableObject
     }
 
     /// <summary>
+    /// Sets the BasePage and CurrentPage properties to NewPage, resetting the Page's shown DataRecord Page.
+    /// </summary>
+    /// <param name="NewPage"></param>
+    private void SetNewPage(NotifyTaskCompletion<Models.Datasources.Page> NewPage)
+    {
+        BasePage = NewPage;
+        CurrentPage = NewPage;
+    }
+
+    /// <summary>
     /// Creates a ViewModel for the DataTablePage.
     /// </summary>
     /// <param name="DataTablePath">The desired display Database Table's full path.</param>
@@ -110,7 +135,8 @@ public partial class DataTableViewModel : ObservableObject
         {
             // create a DataTable from the path passed in DataTablePath
             Table = new DataTable(DataTablePath);
-            Data = new NotifyTaskCompletion<Models.Datasources.Page>(Table.RequestPage(0, Options.ShownRecordCount));
+            // display the first Page in the DataTable with the default PageLength
+            SetNewPage(new NotifyTaskCompletion<Models.Datasources.Page>(Table.RequestPage(0, Options.ShownRecordCount)));
             Options.Process = Table.Process;
             Options.LeftPanelHeaderText = Table.Process!.FullName;
             Options.SetBodyHeaderModeToLabel("Loading records...");
@@ -118,9 +144,6 @@ public partial class DataTableViewModel : ObservableObject
         } 
         else 
         {
-            // set the table to null
-            Table = null;
-            Data = null;
             Options.SetBodyHeaderModeToLabel("Select Process...");
         }
     }

--- a/LotCoMClient/ViewModels/DataTableViewModel.cs
+++ b/LotCoMClient/ViewModels/DataTableViewModel.cs
@@ -222,6 +222,18 @@ public partial class DataTableViewModel : ObservableObject
     }
 
     /// <summary>
+    /// Refreshes the DataTable's PageSets to display a new PageSet with the passed configurations.
+    /// </summary>
+    /// <param name="MaxCount">(Optional) Set a limit on the number of Pages allowed in the PageSet.</param>
+    /// <returns></returns>
+    public async Task RefreshPages(int MaxCount = -1)
+    {
+        await Table!.RefreshPages(MaxCount, Options.PageLength);
+        // update the DataTablePage to show the Active Page of the new PageSet
+        SetNewPage(new NotifyTaskCompletion<Models.Datasources.Page>(Table!.ActivePageSet.GetActivePage()));
+    }
+
+    /// <summary>
     /// Sorts the DataRecords in the CurrentPage property using the Sorting Field and orders it according to the Order selection.
     /// </summary>
     /// <returns></returns>

--- a/LotCoMClient/ViewModels/DataTableViewModel.cs
+++ b/LotCoMClient/ViewModels/DataTableViewModel.cs
@@ -65,7 +65,8 @@ public partial class DataTableViewModel : ObservableObject
     private static string ResolveDataRecordPropertyName(string String) 
     {
         // create a conversion Library to convert plaintext selections to DataRecord property names
-        Dictionary<string, string> Conversions = new Dictionary<string, string>() {
+        Dictionary<string, string> Conversions = new Dictionary<string, string>() 
+        {
             {"Part Number", "RecordPart.PartNumber"},
             {"Part Name", "RecordPart.PartName"},
             {"Quantity", "Quantity"},
@@ -100,18 +101,19 @@ public partial class DataTableViewModel : ObservableObject
     /// <param name="IsProcessAssigned">Indicates whether the Selector Page has been assigned a Process (True by default).</param>
     public DataTableViewModel(string DataTablePath, string PageTitle, Type RecordType, bool IsProcessAssigned = true) 
     {
-        // assign properties
+        // configure the Page's basic properties
         Options.Title = PageTitle;
         Options.RecordType = RecordType;
+        Options.IsProcessAssigned = IsProcessAssigned;
         // configure the Page based on whether an initial Process is assigned
-        if (IsProcessAssigned) 
+        if (Options.IsProcessAssigned) 
         {
             // create a DataTable from the path passed in DataTablePath
             Table = new DataTable(DataTablePath);
             Data = new NotifyTaskCompletion<List<DataRecord>>(Table.ReadRecordsAsync());
-            // set the left frame panel's header
+            Options.Process = new ProcessData().GetIndividualProcess(Table.TableProcess);
             Options.LeftPanelHeaderText = Table!.TableProcess;
-            Options.BodyTableHeaderText = "Loading records...";
+            Options.SetBodyHeaderModeToLabel("Loading records...");
         // no Process is assigned at instantiation
         } 
         else 
@@ -119,9 +121,7 @@ public partial class DataTableViewModel : ObservableObject
             // set the table to null
             Table = null;
             Data = null;
-            // set the left frame panel's header to a default no process string
-            Options.LeftPanelHeaderText = "Select Process...";
-            Options.BodyTableHeaderText = "";
+            Options.SetBodyHeaderModeToLabel("Select Process...");
         }
     }
 

--- a/LotCoMClient/ViewModels/DataTableViewModel.cs
+++ b/LotCoMClient/ViewModels/DataTableViewModel.cs
@@ -182,6 +182,46 @@ public partial class DataTableViewModel : ObservableObject
     }
 
     /// <summary>
+    /// Jumps to the first Page in the Table's current Pages (the newest Records).
+    /// </summary>
+    public async Task GoToFirstPage()
+    {
+        await Table!.GoToFirstPage();
+        // update the DataTablePage to show the new Active Page of the PageSet
+        SetNewPage(new NotifyTaskCompletion<Models.Datasources.Page>(Table!.ActivePageSet.GetActivePage()));
+    }
+
+    /// <summary>
+    /// Goes to the previous Page in the Table's current Pages (if one exists).
+    /// </summary>
+    public async Task GoToPreviousPage()
+    {
+        await Table!.GoToPreviousPage();
+        // update the DataTablePage to show the new Active Page of the PageSet
+        SetNewPage(new NotifyTaskCompletion<Models.Datasources.Page>(Table!.ActivePageSet.GetActivePage()));
+    }
+
+    /// <summary>
+    /// Jumps to the last Page in the Table's current Pages (the oldest Records).
+    /// </summary>
+    public async Task GoToLastPage()
+    {
+        await Table!.GoToLastPage();
+        // update the DataTablePage to show the new Active Page of the PageSet
+        SetNewPage(new NotifyTaskCompletion<Models.Datasources.Page>(Table!.ActivePageSet.GetActivePage()));
+    }
+
+    /// <summary>
+    /// Goes to the next Page in the Table's current Pages (if one exists).
+    /// </summary>
+    public async Task GoToNextPage()
+    {
+        await Table!.GoToLastPage();
+        // update the DataTablePage to show the new Active Page of the PageSet
+        SetNewPage(new NotifyTaskCompletion<Models.Datasources.Page>(Table!.ActivePageSet.GetActivePage()));
+    }
+
+    /// <summary>
     /// Sorts the DataRecords in the CurrentPage property using the Sorting Field and orders it according to the Order selection.
     /// </summary>
     /// <returns></returns>

--- a/LotCoMClient/ViewModels/DataTableViewModel.cs
+++ b/LotCoMClient/ViewModels/DataTableViewModel.cs
@@ -3,6 +3,7 @@ using LotCoMClient.Models.Datasources;
 using LotCoMClient.Models.Options;
 using LotCoMClient.Models.Services;
 using System.Linq.Dynamic;
+using System.Threading.Tasks;
 
 namespace LotCoMClient.ViewModels;
 
@@ -195,41 +196,37 @@ public partial class DataTableViewModel : ObservableObject
     /// <summary>
     /// Jumps to the first Page in the Table's current Pages (the newest Records).
     /// </summary>
-    public async Task GoToFirstPage()
+    public void GoToFirstPage()
     {
-        await Table!.GoToFirstPage();
         // update the DataTablePage to show the new Active Page of the PageSet
-        SetNewPage(new NotifyTaskCompletion<Models.Datasources.Page>(Table!.ActivePageSet.GetActivePage()));
+        SetNewPage(new NotifyTaskCompletion<Models.Datasources.Page>(Table!.GoToFirstPage()));
     }
 
     /// <summary>
     /// Goes to the previous Page in the Table's current Pages (if one exists).
     /// </summary>
-    public async Task GoToPreviousPage()
+    public void GoToPreviousPage()
     {
-        await Table!.GoToPreviousPage();
         // update the DataTablePage to show the new Active Page of the PageSet
-        SetNewPage(new NotifyTaskCompletion<Models.Datasources.Page>(Table!.ActivePageSet.GetActivePage()));
+        SetNewPage(new NotifyTaskCompletion<Models.Datasources.Page>(Table!.GoToPreviousPage()));
     }
 
     /// <summary>
     /// Jumps to the last Page in the Table's current Pages (the oldest Records).
     /// </summary>
-    public async Task GoToLastPage()
+    public void GoToLastPage()
     {
-        await Table!.GoToLastPage();
         // update the DataTablePage to show the new Active Page of the PageSet
-        SetNewPage(new NotifyTaskCompletion<Models.Datasources.Page>(Table!.ActivePageSet.GetActivePage()));
+        SetNewPage(new NotifyTaskCompletion<Models.Datasources.Page>(Table!.GoToLastPage()));
     }
 
     /// <summary>
     /// Goes to the next Page in the Table's current Pages (if one exists).
     /// </summary>
-    public async Task GoToNextPage()
+    public void GoToNextPage()
     {
-        await Table!.GoToNextPage();
         // update the DataTablePage to show the new Active Page of the PageSet
-        SetNewPage(new NotifyTaskCompletion<Models.Datasources.Page>(Table!.ActivePageSet.GetActivePage()));
+        SetNewPage(new NotifyTaskCompletion<Models.Datasources.Page>(Table!.GoToNextPage()));
     }
 
     /// <summary>
@@ -237,11 +234,10 @@ public partial class DataTableViewModel : ObservableObject
     /// </summary>
     /// <param name="MaxCount">(Optional) Set a limit on the number of Pages allowed in the PageSet.</param>
     /// <returns></returns>
-    public async Task RefreshPages(int MaxCount = -1)
+    public void RefreshPages(int MaxCount = -1)
     {
-        await Table!.RefreshPages(MaxCount, Options.PageLength);
         // update the DataTablePage to show the Active Page of the new PageSet
-        SetNewPage(new NotifyTaskCompletion<Models.Datasources.Page>(Table!.ActivePageSet.GetActivePage()));
+        SetNewPage(new NotifyTaskCompletion<Models.Datasources.Page>(Table!.RefreshPages(MaxCount, Options.PageLength)));
     }
 
     /// <summary>

--- a/LotCoMClient/Views/DataTablePage.xaml
+++ b/LotCoMClient/Views/DataTablePage.xaml
@@ -365,10 +365,11 @@
                     <!-- Page Length (Shown Record Number) Picker -->
                     <Picker
                         x:Name="PageLengthPicker"
+                        SelectedIndex="{Binding Options.SelectedPageLengthIndex}"
+                        SelectedIndexChanged="OnPageLengthPickerSelectedIndexChanged"
                         Grid.Row="0"
                         Grid.RowSpan="2"
                         Grid.Column="3"
-                        SelectedIndex="{Binding Options.SelectedPageLengthIndex}"
                         Margin="0,0,0,2"
                         HorizontalOptions="Center"
                         VerticalOptions="End">

--- a/LotCoMClient/Views/DataTablePage.xaml
+++ b/LotCoMClient/Views/DataTablePage.xaml
@@ -539,11 +539,15 @@
                                         <!-- Left-Side Padding Column -->
                                         <ColumnDefinition Width="25"/>
                                         <!-- Date Column -->
-                                        <ColumnDefinition Width="125"/>
+                                        <ColumnDefinition Width="Auto"/>
                                         <!-- Time Column -->
-                                        <ColumnDefinition Width="125"/>
+                                        <ColumnDefinition Width="Auto"/>
+                                        <!-- ScanRecord Scanner Address Column -->
+                                        <ColumnDefinition Width="Auto"/>
+                                        <!-- ScanRecord Production Timestamp Column -->
+                                        <ColumnDefinition Width="Auto"/>
                                         <!-- Shift Column -->
-                                        <ColumnDefinition Width="125"/>
+                                        <ColumnDefinition Width="Auto"/>
                                         <!-- Operator Column -->
                                         <ColumnDefinition Width="*"/>
                                     </Grid.ColumnDefinitions>
@@ -552,7 +556,7 @@
                                         Margin="0,10,0,0"
                                         Grid.Row="0"
                                         Grid.Column="1"
-                                        Grid.ColumnSpan="4">
+                                        Grid.ColumnSpan="6">
                                         <!-- DataRecord Part Number -->
                                         <Label
                                             Text="{Binding RecordPart.PartNumber, StringFormat='Part: {0}'}"
@@ -631,21 +635,41 @@
                                         FontSize="12"
                                         TextColor="{StaticResource Gray500}"
                                         VerticalOptions="Start"/>
-                                    <!-- DataRecord Shift Label -->
+                                    <!-- ScanRecord Scanner Address Label -->
                                     <Label
-                                        Margin="5,0,0,0"
+                                        Margin="20,0,0,0"
+                                        IsVisible="{Binding IsScanRecord}"
                                         Grid.Row="1"
                                         Grid.Column="3"
+                                        Text="{Binding ScanAddress, StringFormat='Scanner: {0}'}"
+                                        FontSize="12"
+                                        TextColor="{StaticResource Gray500}"
+                                        VerticalOptions="Start"/>
+                                    <!-- ScanRecord Production Timestamp -->
+                                    <Label 
+                                        Margin="20,0,0,0"
+                                        IsVisible="{Binding IsScanRecord}"
+                                        Grid.Row="1"
+                                        Grid.Column="4"
+                                        Text="{Binding ProductionTimestamp, StringFormat='Produced: {0}'}"
+                                        FontSize="12"
+                                        TextColor="{StaticResource Gray500}"
+                                        VerticalOptions="Start"/>
+                                    <!-- DataRecord Shift Label -->
+                                    <Label
+                                        Margin="10,0,0,0"
+                                        Grid.Row="1"
+                                        Grid.Column="5"
                                         Text="{Binding RecordShift, StringFormat='Shift: {0}'}"
                                         FontSize="12"
                                         TextColor="{StaticResource Gray500}"
                                         VerticalOptions="Start"/>
-                                    <!-- DataRecord Operator Label -->
-                                    <Label
-                                        Margin="5,0,0,0"
+                                    <!-- DataRecord Production Operator -->
+                                    <Label 
+                                        Margin="10,0,0,0"
                                         Grid.Row="1"
-                                        Grid.Column="4"
-                                        Text="{Binding OperatorID, StringFormat='ID: {0}'}"
+                                        Grid.Column="6"
+                                        Text="{Binding OperatorID, StringFormat='Operator: {0}'}"
                                         FontSize="12"
                                         TextColor="{StaticResource Gray500}"
                                         VerticalOptions="Start"/>
@@ -653,7 +677,7 @@
                                     <BoxView
                                         Grid.Row="2"
                                         Grid.Column="0"
-                                        Grid.ColumnSpan="5"
+                                        Grid.ColumnSpan="7"
                                         HeightRequest="1"
                                         HorizontalOptions="Fill"
                                         VerticalOptions="Center"

--- a/LotCoMClient/Views/DataTablePage.xaml
+++ b/LotCoMClient/Views/DataTablePage.xaml
@@ -140,6 +140,7 @@
                         <!-- ListView Sorting Field Picker -->
                         <Picker
                             x:Name="ListViewSortingFieldPicker"
+                            SelectedIndex="{Binding Options.SelectedSortingFieldIndex}"
                             SelectedIndexChanged="OnSortParameterSelectedIndexChanged"
                             Grid.Row="1"
                             Grid.Column="0"
@@ -154,6 +155,7 @@
                         <!-- ListView Sorting Order Picker -->
                         <Picker
                             x:Name="ListViewSortingOrderPicker"
+                            SelectedIndex="{Binding Options.SelectedSortingOrderIndex}"
                             SelectedIndexChanged="OnSortParameterSelectedIndexChanged"
                             Grid.Row="2"
                             Grid.Column="0"
@@ -216,6 +218,7 @@
                         <Picker
                             x:Name="ListViewSearchingFieldPicker"
                             SelectedIndex="{Binding Options.SelectedSearchingFieldIndex}"
+                            SelectedItem="All"
                             Grid.Row="5"
                             Grid.Column="0"
                             Margin="10"

--- a/LotCoMClient/Views/DataTablePage.xaml
+++ b/LotCoMClient/Views/DataTablePage.xaml
@@ -462,7 +462,7 @@
                     <Label
                         Grid.Row="2"
                         Grid.Column="3"
-                        Text="Page #"
+                        Text="{Binding PageNumberContext}"
                         HorizontalOptions="Center"
                         VerticalOptions="Center"/>
                     <!-- Older Button (forward to next) -->

--- a/LotCoMClient/Views/DataTablePage.xaml
+++ b/LotCoMClient/Views/DataTablePage.xaml
@@ -397,6 +397,7 @@
                     <!-- Newest Button (back to start) -->
                     <Button 
                         x:Name="GoToFirstPageButton"
+                        Clicked="OnGoToFirstPageButtonClicked"
                         Grid.Row="2"
                         Grid.Column="1"
                         Padding="10"
@@ -410,6 +411,7 @@
                     <!-- Newer Button (back to previous) -->
                     <Button 
                         x:Name="GoToPreviousPageButton"
+                        Clicked="OnGoToPreviousPageButtonClicked"
                         Grid.Row="2"
                         Grid.Column="2"
                         Padding="10"
@@ -430,6 +432,7 @@
                     <!-- Older Button (forward to next) -->
                     <Button 
                         x:Name="GoToNextPageButton"
+                        Clicked="OnGoToNextPageButtonClicked"
                         Grid.Row="2"
                         Grid.Column="4"
                         Padding="10"
@@ -443,6 +446,7 @@
                     <!-- Oldest Button (forward to end) -->
                     <Button 
                         x:Name="GoToLastPageButton"
+                        Clicked="OnGoToLastPageButtonClicked"
                         Grid.Row="2"
                         Grid.Column="5"
                         Padding="10"
@@ -456,7 +460,7 @@
                 </Grid>
             </HorizontalStackLayout>
                 
-            <!-- Page Body Table ScrollView -->
+            <!-- Page Body ScrollView -->
             <!-- Activity Indicator (Shows While Loading Data) -->
             <ActivityIndicator 
                 x:Name="DataLoadingActivityIndicator"

--- a/LotCoMClient/Views/DataTablePage.xaml
+++ b/LotCoMClient/Views/DataTablePage.xaml
@@ -34,21 +34,21 @@
         <!-- Title Frame -->
         <!-- Top-Left Page Corner Frame -->
         <BoxView
-            x:Name="PageTopLeftCornerFrameFill"
+            x:Name="TopLeftCornerFrameFill"
             Grid.Row="0"
             Grid.Column="0"
             WidthRequest="{Binding Options.LeftPanelWidth}"
             BackgroundColor="{AppThemeBinding Light={StaticResource Framing}, Dark={StaticResource FramingDark}}"/>
         <!-- Title Frame -->
         <VerticalStackLayout
-            x:Name="PageTitleFrameLayout"
+            x:Name="TitleFrameLayout"
             Grid.Row="0"
             Grid.Column="1"
             Margin="0"
             BackgroundColor="{AppThemeBinding Light={StaticResource Framing}, Dark={StaticResource FramingDark}}">
             <!-- Title Label -->
             <Label
-                x:Name="PageTitleFrameLabel"
+                x:Name="TitleFrameLabel"
                 Text="{Binding Options.Title}"
                 TextColor="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}"
                 FontAttributes="None"
@@ -58,16 +58,16 @@
                 VerticalOptions="Center"/>
             <!-- Title Frame Bottom Border -->
             <BoxView
-                x:Name="PageTitleFrameBottomBorder"
+                x:Name="TitleFrameBottomBorder"
                 HeightRequest="1"
                 HorizontalOptions="Fill"
                 VerticalOptions="End"
                 BackgroundColor="{AppThemeBinding Light={StaticResource Foreground}, Dark={StaticResource ForegroundDark}}"/>
         </VerticalStackLayout>
 
-        <!-- Left-Side Frame -->
+        <!-- Left Panel -->
         <HorizontalStackLayout
-            x:Name="PageLeftFrameLayout"
+            x:Name="LeftPanelLayout"
             Grid.Row="1"
             Grid.Column="0"
             Margin="0"
@@ -238,9 +238,9 @@
                     </Grid>
                 </ScrollView>
 
-                <!-- Left Frame Footer Label -->
+                <!-- Left Panel Footer Label -->
                 <Label 
-                    x:Name="PageLeftFrameFooterLabel"
+                    x:Name="LeftPanelFooterLabel"
                     IsVisible="{Binding Options.IsLeftPanelShown}"
                     Margin="10,0,0,15"
                     Grid.Row="2"
@@ -253,7 +253,7 @@
                 
                 <!-- Panel Collapse Button -->
                 <Button
-                    x:Name="PageLeftFrameCollapseButton"
+                    x:Name="LeftPanelCollapseButton"
                     Clicked="OnPageLeftFrameCollapseButtonClicked"
                     Margin="-14,10,1,0"
                     Padding="10"
@@ -266,9 +266,9 @@
                     CornerRadius="30"
                     ImageSource="{AppThemeBinding Light=left_arrow_black.png, Dark=left_arrow_white.png}"/>
 
-                <!-- Left Frame Right Border -->
+                <!-- Left Panel Right Border -->
                 <BoxView
-                    x:Name="PageLeftFrameRightBorder"
+                    x:Name="LeftPanelRightBorder"
                     IsVisible="true"
                     Grid.Row="0"
                     Grid.RowSpan="3"
@@ -280,9 +280,9 @@
             </Grid>
         </HorizontalStackLayout>
 
-        <!-- Left Frame Header Label (Defined outside of frame for positioning) -->
+        <!-- Left Panel Header Label (Defined outside of Panel for positioning) -->
         <Label 
-            x:Name="PageLeftFrameHeaderLabel"
+            x:Name="LeftPanelHeaderLabel"
             IsVisible="{Binding Options.IsLeftPanelShown}"
             Margin="0"
             Grid.Row="0"
@@ -309,16 +309,16 @@
                 <ColumnDefinition Width="*"/>
             </Grid.ColumnDefinitions>
 
-            <!-- Horizontal Layout For Body Table Header and Page Navigation Controls -->
+            <!-- Horizontal Layout For Body Header and Page Navigation Controls -->
             <HorizontalStackLayout
                 Grid.Row="0"
                 Grid.Column="0"
                 Grid.ColumnSpan="1">
-                <!-- Page Body Table Header Label -->
+                <!-- Page Body Header Label -->
                 <Label 
-                    x:Name="PageBodyTableHeaderLabel"
+                    x:Name="BodyHeaderLabel"
                     IsVisible="{Binding Options.IsBodyHeaderLabelShown}"
-                    Text="{Binding Options.BodyTableHeaderText}"
+                    Text="{Binding Options.BodyHeaderText}"
                     TextColor="{AppThemeBinding Light={StaticResource Black}, Dark={StaticResource White}}"
                     FontAttributes="None"
                     FontSize="16"
@@ -362,13 +362,13 @@
                         FontSize="16"
                         HorizontalOptions="Center"
                         VerticalOptions="Center"/>
-                    <!-- Shown Record Count Picker -->
+                    <!-- Page Length (Shown Record Number) Picker -->
                     <Picker
-                        x:Name="ShownRecordCountPicker"
+                        x:Name="PageLengthPicker"
                         Grid.Row="0"
                         Grid.RowSpan="2"
                         Grid.Column="3"
-                        SelectedIndex="{Binding Options.SelectedShownRecordCountIndex}"
+                        SelectedIndex="{Binding Options.SelectedPageLengthIndex}"
                         Margin="0,0,0,2"
                         HorizontalOptions="Center"
                         VerticalOptions="End">
@@ -396,6 +396,7 @@
                         VerticalOptions="Center"/>
                     <!-- Newest Button (back to start) -->
                     <Button 
+                        x:Name="GoToFirstPageButton"
                         Grid.Row="2"
                         Grid.Column="1"
                         Padding="10"
@@ -408,6 +409,7 @@
                         VerticalOptions="Center"/>
                     <!-- Newer Button (back to previous) -->
                     <Button 
+                        x:Name="GoToPreviousPageButton"
                         Grid.Row="2"
                         Grid.Column="2"
                         Padding="10"
@@ -427,6 +429,7 @@
                         VerticalOptions="Center"/>
                     <!-- Older Button (forward to next) -->
                     <Button 
+                        x:Name="GoToNextPageButton"
                         Grid.Row="2"
                         Grid.Column="4"
                         Padding="10"
@@ -439,6 +442,7 @@
                         VerticalOptions="Center"/>
                     <!-- Oldest Button (forward to end) -->
                     <Button 
+                        x:Name="GoToLastPageButton"
                         Grid.Row="2"
                         Grid.Column="5"
                         Padding="10"
@@ -455,7 +459,7 @@
             <!-- Page Body Table ScrollView -->
             <!-- Activity Indicator (Shows While Loading Data) -->
             <ActivityIndicator 
-                x:Name="PageDataLoadingActivityIndicator"
+                x:Name="DataLoadingActivityIndicator"
                 IsEnabled="{Binding CurrentPage.IsNotCompleted}"
                 IsVisible="{Binding CurrentPage.IsNotCompleted}"
                 IsRunning="{Binding CurrentPage.IsNotCompleted}"
@@ -466,13 +470,13 @@
                 HeightRequest="200"/>
             <!-- Actual View -->
             <ScrollView
-                x:Name="PageBodyTableScrollView"
+                x:Name="BodyScrollView"
                 IsVisible="{Binding CurrentPage.IsCompleted}"
                 Grid.Row="1"
                 Grid.Column="0">
                 <!-- Page Data Table List View -->
                 <ListView
-                    x:Name="PageDataTableListView"
+                    x:Name="DataTableListView"
                     ItemsSource="{Binding CurrentPage.Result.DataRecords}"
                     PropertyChanged="OnPageDataTableListViewPropertyChanged"
                     Margin="20">

--- a/LotCoMClient/Views/DataTablePage.xaml
+++ b/LotCoMClient/Views/DataTablePage.xaml
@@ -389,7 +389,7 @@
                         Grid.Column="4"
                         Grid.ColumnSpan="3"
                         Margin="5,0,5,0"
-                        Text="{Binding Options.TotalRecordCount, StringFormat='of {0} records'}"
+                        Text="{Binding Data.Result.Count, StringFormat='of {0} records'}"
                         TextColor="{AppThemeBinding Light={StaticResource PrimaryText}, Dark={StaticResource PrimaryTextDark}}"
                         FontSize="16"
                         HorizontalOptions="Start"

--- a/LotCoMClient/Views/DataTablePage.xaml
+++ b/LotCoMClient/Views/DataTablePage.xaml
@@ -102,11 +102,15 @@
                             <RowDefinition Height="Auto"/>
                             <!-- ListView Sorting Order Picker Row -->
                             <RowDefinition Height="Auto"/>
+                            <!-- ListView Sorting Clear Button Row -->
+                            <RowDefinition Height="Auto"/>
                             <!-- ListView Searching Label Row -->
                             <RowDefinition Height="Auto"/>
                             <!-- ListView Searching SearchBar Row -->
                             <RowDefinition Height="Auto"/>
                             <!-- ListView Searching Field Picker Row -->
+                            <RowDefinition Height="Auto"/>
+                            <!-- ListView Searching Clear Button Row -->
                             <RowDefinition Height="Auto"/>
                             <!-- Expand Rows to Add Frame Entries -->
                             <RowDefinition Height="*"/>
@@ -173,9 +177,23 @@
                                 </x:Array>
                             </Picker.ItemsSource>
                         </Picker>
+                        <!-- ListView Sort Clear Button -->
+                        <Button 
+                            x:Name="ListViewSortingClearButton"
+                            Clicked="OnListViewFilterClearButtonClicked"
+                            Grid.Row="3"
+                            Grid.Column="0"
+                            Text="Reset"
+                            FontSize="10"
+                            Margin="11,0,0,12"
+                            CornerRadius="3"
+                            WidthRequest="65"
+                            HeightRequest="30"
+                            HorizontalOptions="Start"
+                            VerticalOptions="Center"/>
                         <!-- Sorting Panel Lower Border BoxView -->
                         <BoxView
-                            Grid.Row="2"
+                            Grid.Row="3"
                             Grid.Column="0"
                             Margin="0,0,1,0"
                             HorizontalOptions="Fill"
@@ -184,7 +202,7 @@
                             BackgroundColor="{AppThemeBinding Light={StaticResource Foreground}, Dark={StaticResource ForegroundDark}}"/>
                         <!-- Searching Panel Upper Border BoxView -->
                         <BoxView
-                            Grid.Row="3"
+                            Grid.Row="4"
                             Grid.Column="0"
                             Margin="0,0,1,0"
                             HorizontalOptions="Fill"
@@ -193,7 +211,7 @@
                             BackgroundColor="{AppThemeBinding Light={StaticResource Foreground}, Dark={StaticResource ForegroundDark}}"/>
                         <!-- ListView Searching Label -->
                         <Label 
-                            Grid.Row="3"
+                            Grid.Row="4"
                             Grid.Column="0"
                             Text="Search Records"
                             TextColor="{AppThemeBinding Light={StaticResource SecondaryText}, Dark={StaticResource SecondaryTextDark}}"
@@ -207,7 +225,7 @@
                             x:Name="ListViewSearchingSearchBar"
                             SearchButtonPressed="OnListViewSearchButtonPressed"
                             Text="{Binding Options.SearchTerm}"
-                            Grid.Row="4"
+                            Grid.Row="5"
                             Grid.Column="0"
                             Margin="10"
                             FontSize="10"
@@ -219,7 +237,7 @@
                             x:Name="ListViewSearchingFieldPicker"
                             SelectedIndex="{Binding Options.SelectedSearchingFieldIndex}"
                             SelectedItem="All"
-                            Grid.Row="5"
+                            Grid.Row="6"
                             Grid.Column="0"
                             Margin="10"
                             Title="Search field"
@@ -229,9 +247,23 @@
                             HeightRequest="65"
                             HorizontalOptions="Start"
                             VerticalOptions="Center"/>
+                        <!-- ListView Search Clear Button -->
+                        <Button 
+                            x:Name="ListViewSearchingClearButton"
+                            Clicked="OnListViewFilterClearButtonClicked"
+                            Grid.Row="7"
+                            Grid.Column="0"
+                            Text="Clear"
+                            FontSize="10"
+                            Margin="11,0,0,12"
+                            CornerRadius="3"
+                            WidthRequest="65"
+                            HeightRequest="30"
+                            HorizontalOptions="Start"
+                            VerticalOptions="Center"/>
                         <!-- Searching Panel Lower Border BoxView -->
                         <BoxView
-                            Grid.Row="5"
+                            Grid.Row="7"
                             Grid.Column="0"
                             Margin="0,0,1,0"
                             HorizontalOptions="Fill"

--- a/LotCoMClient/Views/DataTablePage.xaml
+++ b/LotCoMClient/Views/DataTablePage.xaml
@@ -389,7 +389,7 @@
                         Grid.Column="4"
                         Grid.ColumnSpan="3"
                         Margin="5,0,5,0"
-                        Text="{Binding Data.Result.Count, StringFormat='of {0} records'}"
+                        Text="{Binding Table.RecordCount, StringFormat='of {0} records'}"
                         TextColor="{AppThemeBinding Light={StaticResource PrimaryText}, Dark={StaticResource PrimaryTextDark}}"
                         FontSize="16"
                         HorizontalOptions="Start"
@@ -456,9 +456,9 @@
             <!-- Activity Indicator (Shows While Loading Data) -->
             <ActivityIndicator 
                 x:Name="PageDataLoadingActivityIndicator"
-                IsEnabled="{Binding Data.IsNotCompleted}"
-                IsVisible="{Binding Data.IsNotCompleted}"
-                IsRunning="{Binding Data.IsNotCompleted}"
+                IsEnabled="{Binding CurrentPage.IsNotCompleted}"
+                IsVisible="{Binding CurrentPage.IsNotCompleted}"
+                IsRunning="{Binding CurrentPage.IsNotCompleted}"
                 Grid.Row="1"
                 Grid.Column="0"
                 Color="{StaticResource Secondary}"
@@ -467,13 +467,13 @@
             <!-- Actual View -->
             <ScrollView
                 x:Name="PageBodyTableScrollView"
-                IsVisible="{Binding Data.IsCompleted}"
+                IsVisible="{Binding CurrentPage.IsCompleted}"
                 Grid.Row="1"
                 Grid.Column="0">
                 <!-- Page Data Table List View -->
                 <ListView
                     x:Name="PageDataTableListView"
-                    ItemsSource="{Binding Data.Result}"
+                    ItemsSource="{Binding CurrentPage.Result.DataRecords}"
                     PropertyChanged="OnPageDataTableListViewPropertyChanged"
                     Margin="20">
                     <!-- Configure DataRecord ItemTemplate -->

--- a/LotCoMClient/Views/DataTablePage.xaml
+++ b/LotCoMClient/Views/DataTablePage.xaml
@@ -425,7 +425,7 @@
                         Grid.Column="4"
                         Grid.ColumnSpan="3"
                         Margin="5,0,5,0"
-                        Text="{Binding Table.RecordCount, StringFormat='of {0} records'}"
+                        Text="{Binding Table.ActivePageSet.EntryCount, StringFormat='of {0} records'}"
                         TextColor="{AppThemeBinding Light={StaticResource PrimaryText}, Dark={StaticResource PrimaryTextDark}}"
                         FontSize="16"
                         HorizontalOptions="Start"

--- a/LotCoMClient/Views/DataTablePage.xaml
+++ b/LotCoMClient/Views/DataTablePage.xaml
@@ -315,17 +315,20 @@
                 Grid.Column="0"
                 Grid.ColumnSpan="1">
                 <!-- Page Body Table Header Label -->
-                <!-- <Label 
+                <Label 
                     x:Name="PageBodyTableHeaderLabel"
+                    IsVisible="{Binding Options.IsBodyHeaderLabelShown}"
                     Text="{Binding Options.BodyTableHeaderText}"
                     TextColor="{AppThemeBinding Light={StaticResource Black}, Dark={StaticResource White}}"
                     FontAttributes="None"
                     FontSize="16"
                     Margin="22,20,20,20"
                     HorizontalOptions="Start"
-                    VerticalOptions="Center"/> -->
+                    VerticalOptions="Center"/>
                 <!-- Page Navigation Control Grid -->
-                <Grid>
+                <Grid
+                    x:Name="BodyHeaderNavigationPanel"
+                    IsVisible="{Binding Options.IsBodyNavigationPanelShown}">
                     <Grid.RowDefinitions>
                         <!-- Padding Row -->
                         <RowDefinition Height="10"/>
@@ -365,17 +368,18 @@
                         Grid.Row="0"
                         Grid.RowSpan="2"
                         Grid.Column="3"
+                        SelectedIndex="{Binding Options.SelectedShownRecordCountIndex}"
                         Margin="0,0,0,2"
                         HorizontalOptions="Center"
                         VerticalOptions="End">
                         <Picker.ItemsSource>
-                            <x:Array Type="{x:Type x:Int16}">
-                                <x:Int16>15</x:Int16>
-                                <x:Int16>25</x:Int16>
-                                <x:Int16>35</x:Int16>
-                                <x:Int16>50</x:Int16>
-                                <x:Int16>75</x:Int16>
-                                <x:Int16>100</x:Int16>
+                            <x:Array Type="{x:Type x:Int32}">
+                                <x:Int32>15</x:Int32>
+                                <x:Int32>25</x:Int32>
+                                <x:Int32>35</x:Int32>
+                                <x:Int32>50</x:Int32>
+                                <x:Int32>75</x:Int32>
+                                <x:Int32>100</x:Int32>
                             </x:Array>
                         </Picker.ItemsSource>
                     </Picker>
@@ -385,7 +389,7 @@
                         Grid.Column="4"
                         Grid.ColumnSpan="3"
                         Margin="5,0,5,0"
-                        Text="of [Record #] records"
+                        Text="{Binding Options.TotalRecordCount, StringFormat='of {0} records'}"
                         TextColor="{AppThemeBinding Light={StaticResource PrimaryText}, Dark={StaticResource PrimaryTextDark}}"
                         FontSize="16"
                         HorizontalOptions="Start"

--- a/LotCoMClient/Views/DataTablePage.xaml
+++ b/LotCoMClient/Views/DataTablePage.xaml
@@ -309,18 +309,144 @@
                 <ColumnDefinition Width="*"/>
             </Grid.ColumnDefinitions>
 
-            <!-- Page Body Table Header Label -->
-            <Label 
-                x:Name="PageBodyTableHeaderLabel"
-                Text="{Binding Options.BodyTableHeaderText}"
+            <!-- Horizontal Layout For Body Table Header and Page Navigation Controls -->
+            <HorizontalStackLayout
                 Grid.Row="0"
                 Grid.Column="0"
-                TextColor="{AppThemeBinding Light={StaticResource Black}, Dark={StaticResource White}}"
-                FontAttributes="None"
-                FontSize="16"
-                Margin="22,20,20,20"
-                HorizontalOptions="Start"
-                VerticalOptions="Center"/>
+                Grid.ColumnSpan="1">
+                <!-- Page Body Table Header Label -->
+                <!-- <Label 
+                    x:Name="PageBodyTableHeaderLabel"
+                    Text="{Binding Options.BodyTableHeaderText}"
+                    TextColor="{AppThemeBinding Light={StaticResource Black}, Dark={StaticResource White}}"
+                    FontAttributes="None"
+                    FontSize="16"
+                    Margin="22,20,20,20"
+                    HorizontalOptions="Start"
+                    VerticalOptions="Center"/> -->
+                <!-- Page Navigation Control Grid -->
+                <Grid>
+                    <Grid.RowDefinitions>
+                        <!-- Padding Row -->
+                        <RowDefinition Height="10"/>
+                        <!-- Showing Records Number Row -->
+                        <RowDefinition Height="50"/>
+                        <!-- Page Number Control Row -->
+                        <RowDefinition Height="40"/>
+                    </Grid.RowDefinitions>
+                    <Grid.ColumnDefinitions>
+                        <!-- Padding Column -->
+                        <ColumnDefinition Width="20"/>
+                        <!-- Newer Records (Back) Page Navigation Controls Columns -->
+                        <ColumnDefinition Width="40"/>
+                        <ColumnDefinition Width="40"/>
+                        <!-- Page Number Label Columns -->
+                        <ColumnDefinition Width="75"/>
+                        <!-- Older Records (Forward) Page Navigation Controls Columns -->
+                        <ColumnDefinition Width="40"/>
+                        <ColumnDefinition Width="40"/>
+                        <!-- "of [Record Number] records" Label Extension Column -->
+                        <ColumnDefinition Width="Auto"/>
+                    </Grid.ColumnDefinitions>
+                    <!-- "Showing" Label -->
+                    <Label 
+                        Grid.Row="1"
+                        Grid.Column="1"
+                        Grid.ColumnSpan="2"
+                        Margin="5,0,5,0"
+                        Text="Showing"
+                        TextColor="{AppThemeBinding Light={StaticResource PrimaryText}, Dark={StaticResource PrimaryTextDark}}"
+                        FontSize="16"
+                        HorizontalOptions="Center"
+                        VerticalOptions="Center"/>
+                    <!-- Shown Record Count Picker -->
+                    <Picker
+                        x:Name="ShownRecordCountPicker"
+                        Grid.Row="0"
+                        Grid.RowSpan="2"
+                        Grid.Column="3"
+                        Margin="0,0,0,2"
+                        HorizontalOptions="Center"
+                        VerticalOptions="End">
+                        <Picker.ItemsSource>
+                            <x:Array Type="{x:Type x:Int16}">
+                                <x:Int16>15</x:Int16>
+                                <x:Int16>25</x:Int16>
+                                <x:Int16>35</x:Int16>
+                                <x:Int16>50</x:Int16>
+                                <x:Int16>75</x:Int16>
+                                <x:Int16>100</x:Int16>
+                            </x:Array>
+                        </Picker.ItemsSource>
+                    </Picker>
+                    <!-- "Of <Record Count>" Label -->
+                    <Label 
+                        Grid.Row="1"
+                        Grid.Column="4"
+                        Grid.ColumnSpan="3"
+                        Margin="5,0,5,0"
+                        Text="of [Record #] records"
+                        TextColor="{AppThemeBinding Light={StaticResource PrimaryText}, Dark={StaticResource PrimaryTextDark}}"
+                        FontSize="16"
+                        HorizontalOptions="Start"
+                        VerticalOptions="Center"/>
+                    <!-- Newest Button (back to start) -->
+                    <Button 
+                        Grid.Row="2"
+                        Grid.Column="1"
+                        Padding="10"
+                        WidthRequest="15"
+                        HeightRequest="15"
+                        CornerRadius="100"
+                        BackgroundColor="Transparent"
+                        ImageSource="{AppThemeBinding Light=left_arrow_black.png, Dark=left_arrow_white.png}"
+                        HorizontalOptions="Center"
+                        VerticalOptions="Center"/>
+                    <!-- Newer Button (back to previous) -->
+                    <Button 
+                        Grid.Row="2"
+                        Grid.Column="2"
+                        Padding="10"
+                        WidthRequest="15"
+                        HeightRequest="15"
+                        CornerRadius="100"
+                        BackgroundColor="Transparent"
+                        ImageSource="{AppThemeBinding Light=left_arrow_black.png, Dark=left_arrow_white.png}"
+                        HorizontalOptions="Center"
+                        VerticalOptions="Center"/>
+                    <!-- Page Number Label -->
+                    <Label
+                        Grid.Row="2"
+                        Grid.Column="3"
+                        Text="Page #"
+                        HorizontalOptions="Center"
+                        VerticalOptions="Center"/>
+                    <!-- Older Button (forward to next) -->
+                    <Button 
+                        Grid.Row="2"
+                        Grid.Column="4"
+                        Padding="10"
+                        WidthRequest="15"
+                        HeightRequest="15"
+                        CornerRadius="100"
+                        BackgroundColor="Transparent"
+                        ImageSource="{AppThemeBinding Light=right_arrow_black.png, Dark=right_arrow_white.png}"
+                        HorizontalOptions="Center"
+                        VerticalOptions="Center"/>
+                    <!-- Oldest Button (forward to end) -->
+                    <Button 
+                        Grid.Row="2"
+                        Grid.Column="5"
+                        Padding="10"
+                        WidthRequest="15"
+                        HeightRequest="15"
+                        CornerRadius="100"
+                        BackgroundColor="Transparent"
+                        ImageSource="{AppThemeBinding Light=right_arrow_black.png, Dark=right_arrow_white.png}"
+                        HorizontalOptions="Center"
+                        VerticalOptions="Center"/>
+                </Grid>
+            </HorizontalStackLayout>
                 
             <!-- Page Body Table ScrollView -->
             <!-- Activity Indicator (Shows While Loading Data) -->

--- a/LotCoMClient/Views/DataTablePage.xaml.cs
+++ b/LotCoMClient/Views/DataTablePage.xaml.cs
@@ -1,3 +1,5 @@
+using LotCoMClient.Models.Services;
+
 namespace LotCoMClient.Views;
 
 /// <summary>
@@ -118,6 +120,20 @@ public partial class DataTablePage : ContentPage
             _viewModel.Options.SelectedSearchingFieldIndex = ListViewSearchingFieldPicker.SelectedIndex;
             _viewModel.SearchDataTable();
         });
+    }
+
+    /// <summary>
+    /// Handler for the Clicked event from the ListViewSearchingClearButton and ListViewSortingClearButton controls. 
+    /// </summary>
+    /// <param name="sender"></param>
+    /// <param name="e"></param>
+    private async void OnListViewFilterClearButtonClicked(object sender, EventArgs e)
+    {
+        // clear the Page's filtering Options, refresh the Base Pages, and reset the Page's CurrentPage
+        _viewModel.ClearFilterOptions();
+        await _viewModel.Table!.RefreshPages(-1, _viewModel.Options.PageLength);
+        await _viewModel.Table!.GoToBasePages();
+        _viewModel.CurrentPage = new NotifyTaskCompletion<Models.Datasources.Page>(_viewModel.Table.ActivePageSet.GetActivePage());
     }
 
     /// <summary>

--- a/LotCoMClient/Views/DataTablePage.xaml.cs
+++ b/LotCoMClient/Views/DataTablePage.xaml.cs
@@ -11,40 +11,40 @@ public partial class DataTablePage : ContentPage
 	private readonly ViewModels.DataTableViewModel _viewModel;
 
     /// <summary>
-    /// Asynchronously evaluates the state of the Data property and configures the Body Header accordingly.
-    /// If Data is loaded, shows the Navigation Panel. Else, shows "Loading Records...".
+    /// Asynchronously evaluates the state of the CurrentPage property and configures the Body Header accordingly.
+    /// If CurrentPage is loaded, shows the Navigation Panel. Else, shows "Loading Records...".
     /// </summary>
     private async Task ConfigureBodyHeader() 
     {
         await Task.Run(() => 
         {
-            // do not do any processing if Data is null (no-Process instantiation)
-            if (_viewModel.Data == null) 
+            // do not do any processing if there is no CurrentPage to show (no-Process instantiation)
+            if (_viewModel.CurrentPage is null) 
             {
                 return;
             }
-            // the Data property is set and is either loading or completed
-            if (_viewModel.Data!.IsCompleted && _viewModel.Data.Result != null) 
+            // the CurrentPage is set and is either loading or completed
+            if (_viewModel.CurrentPage!.IsCompleted && _viewModel.CurrentPage.Result != null) 
             {
-                // update the BodyTableHeader to show the item count and navigation
+                // CurrentPage is loaded; update the BodyTableHeader to show the item count and navigation
                 _viewModel.Options.SetBodyHeaderModeToNavigation();
             } 
             else 
             {
-                // the data is not loaded yet; default Body Table Header options
-                _viewModel.Options.SetBodyHeaderModeToLabel("Loading Records...");
+                // the CurrentPage is not loaded yet; default Body Table Header options
+                _viewModel.Options.SetBodyHeaderModeToLabel("Loading records...");
             }
         });
     }
 
     /// <summary>
-    /// Checks that the Table has DataRecords available. Updates the Data and Search fields based on that Data.
+    /// Checks that the Table has a CurrentPage available. Updates the Data and Search fields based on that Page's DataRecords.
     /// </summary>
     /// <returns></returns>
     private async Task ConfigurePageFields() 
     {
         // confirm that the Data property has completed its async task
-        if (_viewModel.Data == null || _viewModel.Data.IsNotCompleted) 
+        if (_viewModel.CurrentPage is null || _viewModel.CurrentPage.IsNotCompleted) 
         {
             return;
         }
@@ -106,14 +106,11 @@ public partial class DataTablePage : ContentPage
     /// <param name="e"></param>
     public async void OnSortParameterSelectedIndexChanged(object sender, EventArgs e) 
     {
-        await Task.Run(() => 
-        {
-            // update ViewModel sorting indexes
-            _viewModel.Options.SelectedSortingFieldIndex = ListViewSortingFieldPicker.SelectedIndex;
-            _viewModel.Options.SelectedSortingOrderIndex = ListViewSortingOrderPicker.SelectedIndex;
-            // invoke the ViewModel sort method
-            _viewModel.SortDataTable();
-        });
+        // update ViewModel sorting indexes
+        _viewModel.Options.SelectedSortingFieldIndex = ListViewSortingFieldPicker.SelectedIndex;
+        _viewModel.Options.SelectedSortingOrderIndex = ListViewSortingOrderPicker.SelectedIndex;
+        // invoke the ViewModel sort method
+        await _viewModel.SortPage();
     }
 
     /// <summary>

--- a/LotCoMClient/Views/DataTablePage.xaml.cs
+++ b/LotCoMClient/Views/DataTablePage.xaml.cs
@@ -46,57 +46,17 @@ public partial class DataTablePage : ContentPage
     }
 
     /// <summary>
-    /// Checks that the Table has DataRecords available. Updates the Data fields based on that Data.
+    /// Checks that the Table has DataRecords available. Updates the Data and Search fields based on that Data.
     /// </summary>
     /// <returns></returns>
-    private async Task ConfigureDataFields() 
+    private async Task ConfigurePageFields() 
     {
-        // perform the config logic on a new CPU thread
-        await Task.Run(() => 
+        // confirm that the Data property has completed its async task
+        if (_viewModel.Data == null || _viewModel.Data.IsNotCompleted) 
         {
-            // confirm that the Data property has completed its async task
-            if (_viewModel.Data == null || _viewModel.Data.IsNotCompleted) 
-            {
-                return;
-            }
-            List<string> Sortables = ["Part Number", "Part Name", "Quantity"];
-            // add the variably-required DataRecord fields (only if Data is loaded)
-            DataRecord SampleRecord;
-            if (_viewModel.Data.Result != null && _viewModel.Data.Result.Count > 0) 
-            {
-                SampleRecord = _viewModel.Data.Result[0];
-                if (SampleRecord.IncludesJBKNumber) 
-                {
-                    Sortables.Add("JBK Number");
-                }
-                if (SampleRecord.IncludesLotNumber) 
-                {
-                    Sortables.Add("Lot Number");
-                }
-                if (SampleRecord.IncludesDeburrJBKNumber) 
-                {
-                    Sortables.Add("Deburr JBK Number");
-                }
-                if (SampleRecord.IncludesDieNumber) 
-                {
-                    Sortables.Add("Die Number");
-                }
-                if (SampleRecord.IncludesModelNumber) 
-                {
-                    Sortables.Add("Model Number");
-                }
-                if (SampleRecord.IncludesHeatNumber) 
-                {
-                    Sortables.Add("Heat Number");
-                }
-            }
-            Sortables.AddRange(["Production Date", "Production Time", "Production Shift", "Operator ID"]);
-            // update the ViewModel DataFields and SearchableFields property
-            _options.DataFields = Sortables;
-            _options.SearchableFields = Sortables
-                .Prepend("All")
-                .ToList();
-        });
+            return;
+        }
+        await _options.ConfigurePageFields();
     }
 
     /// <summary>
@@ -154,7 +114,7 @@ public partial class DataTablePage : ContentPage
     {
         // update BodyTableHeader property
         await ConfigureBodyHeader();
-        await ConfigureDataFields();
+        await ConfigurePageFields();
     }
 
     /// <summary>

--- a/LotCoMClient/Views/DataTablePage.xaml.cs
+++ b/LotCoMClient/Views/DataTablePage.xaml.cs
@@ -153,6 +153,24 @@ public partial class DataTablePage : ContentPage
     }
 
     /// <summary>
+    /// Handler for the SelectedIndexChanged event from the PageLengthPicker control.
+    /// </summary>
+    /// <param name="sender"></param>
+    /// <param name="e"></param>
+    private async void OnPageLengthPickerSelectedIndexChanged(object sender, EventArgs e)
+    {
+        // get the newly selected PageLength value and update it in the ViewModel
+        if (PageLengthPicker is null)
+        {
+            return;
+        }
+        int PageLength = (int)PageLengthPicker.ItemsSource[_viewModel.Options.SelectedPageLengthIndex]!;
+        _viewModel.Options.PageLength = PageLength;
+        // refresh the Data Table to use a new PageSet based on the selected PageLength
+        await _viewModel.RefreshPages();
+    }
+
+    /// <summary>
     /// Creates a new DataTablePage.
     /// </summary>
     /// <param name="DataTablePath"></param>

--- a/LotCoMClient/Views/DataTablePage.xaml.cs
+++ b/LotCoMClient/Views/DataTablePage.xaml.cs
@@ -90,6 +90,10 @@ public partial class DataTablePage : ContentPage
     private async void OnSortParameterSelectedIndexChanged(object sender, EventArgs e) 
     {
         // update ViewModel sorting indexes
+        if (ListViewSortingFieldPicker is null || ListViewSortingOrderPicker is null)
+        {
+            return;
+        }
         _viewModel.Options.SelectedSortingFieldIndex = ListViewSortingFieldPicker.SelectedIndex;
         _viewModel.Options.SelectedSortingOrderIndex = ListViewSortingOrderPicker.SelectedIndex;
         // invoke the ViewModel sort method
@@ -106,6 +110,10 @@ public partial class DataTablePage : ContentPage
         await Task.Run(() => 
         {
             // invoke the ViewModel local sort method using the current search term
+            if (ListViewSearchingFieldPicker is null)
+            {
+                return;
+            }
             _viewModel.Options.SearchTerm = ListViewSearchingSearchBar.Text;
             _viewModel.Options.SelectedSearchingFieldIndex = ListViewSearchingFieldPicker.SelectedIndex;
             _viewModel.SearchDataTable();
@@ -168,6 +176,7 @@ public partial class DataTablePage : ContentPage
         _viewModel.Options.PageLength = PageLength;
         // refresh the Data Table to use a new PageSet based on the selected PageLength
         await _viewModel.RefreshPages();
+        _viewModel.ClearFilterOptions();
     }
 
     /// <summary>

--- a/LotCoMClient/Views/DataTablePage.xaml.cs
+++ b/LotCoMClient/Views/DataTablePage.xaml.cs
@@ -52,28 +52,11 @@ public partial class DataTablePage : ContentPage
     }
 
     /// <summary>
-    /// Creates a new DataTablePage.
-    /// </summary>
-    /// <param name="DataTablePath"></param>
-    /// <param name="PageTitle">A string to apply as the Page's Title.</param>
-    /// <param name="RecordType">The subclass of DataRecord this Page is meant to display (PrintRecord || ScanRecord).</param>
-    /// <param name="IsProcessAssigned">Indicates whether the Selector Page has been assigned a Process (True by default).</param>
-    public DataTablePage(string DataTablePath, string PageTitle, Type RecordType, bool IsProcessAssigned = true) 
-    {
-		// instantiate the ViewModel
-        _viewModel = new ViewModels.DataTableViewModel(DataTablePath, PageTitle, RecordType, IsProcessAssigned);
-        BindingContext = _viewModel;
-
-        // create the page from XAML
-		InitializeComponent();
-    }
-
-    /// <summary>
     /// Handler for the Clicked event from the PageLeftFrameCollapseButton control.
     /// </summary>
     /// <param name="sender"></param>
     /// <param name="e"></param>
-    public async void OnPageLeftFrameCollapseButtonClicked(object sender, EventArgs e) 
+    private async void OnPageLeftFrameCollapseButtonClicked(object sender, EventArgs e) 
     {
         await Task.Delay(0);
         if (_viewModel.Options.IsLeftPanelShown) 
@@ -92,7 +75,7 @@ public partial class DataTablePage : ContentPage
     /// </summary>
     /// <param name="sender"></param>
     /// <param name="e"></param>
-    public async void OnPageDataTableListViewPropertyChanged(object sender, EventArgs e) 
+    private async void OnPageDataTableListViewPropertyChanged(object sender, EventArgs e) 
     {
         // update BodyTableHeader property
         await ConfigureBodyHeader();
@@ -104,7 +87,7 @@ public partial class DataTablePage : ContentPage
     /// </summary>
     /// <param name="sender"></param>
     /// <param name="e"></param>
-    public async void OnSortParameterSelectedIndexChanged(object sender, EventArgs e) 
+    private async void OnSortParameterSelectedIndexChanged(object sender, EventArgs e) 
     {
         // update ViewModel sorting indexes
         _viewModel.Options.SelectedSortingFieldIndex = ListViewSortingFieldPicker.SelectedIndex;
@@ -118,7 +101,7 @@ public partial class DataTablePage : ContentPage
     /// </summary>
     /// <param name="sender"></param>
     /// <param name="e"></param>
-    public async void OnListViewSearchButtonPressed(object sender, EventArgs e) 
+    private async void OnListViewSearchButtonPressed(object sender, EventArgs e) 
     {
         await Task.Run(() => 
         {
@@ -127,5 +110,62 @@ public partial class DataTablePage : ContentPage
             _viewModel.Options.SelectedSearchingFieldIndex = ListViewSearchingFieldPicker.SelectedIndex;
             _viewModel.SearchDataTable();
         });
+    }
+
+    /// <summary>
+    /// Handler for the Clicked event from the OnGoToFirstPageButtonClicked control.
+    /// </summary>
+    /// <param name="sender"></param>
+    /// <param name="e"></param>
+    private async void OnGoToFirstPageButtonClicked(object sender, EventArgs e)
+    {
+        await _viewModel.GoToFirstPage();
+    }
+
+    /// <summary>
+    /// Handler for the Clicked event from the OnGoToPreviousPageButtonClicked control.
+    /// </summary>
+    /// <param name="sender"></param>
+    /// <param name="e"></param>
+    private async void OnGoToPreviousPageButtonClicked(object sender, EventArgs e)
+    {
+        await _viewModel.GoToPreviousPage();
+    }
+
+    /// <summary>
+    /// Handler for the Clicked event from the OnGoToNextPageButtonClicked control.
+    /// </summary>
+    /// <param name="sender"></param>
+    /// <param name="e"></param>
+    private async void OnGoToNextPageButtonClicked(object sender, EventArgs e)
+    {
+        await _viewModel.GoToNextPage();
+    }
+
+    /// <summary>
+    /// Handler for the Clicked event from the OnGoToLastPageButtonClicked control.
+    /// </summary>
+    /// <param name="sender"></param>
+    /// <param name="e"></param>
+    private async void OnGoToLastPageButtonClicked(object sender, EventArgs e)
+    {
+        await _viewModel.GoToLastPage();
+    }
+
+    /// <summary>
+    /// Creates a new DataTablePage.
+    /// </summary>
+    /// <param name="DataTablePath"></param>
+    /// <param name="PageTitle">A string to apply as the Page's Title.</param>
+    /// <param name="RecordType">The subclass of DataRecord this Page is meant to display (PrintRecord || ScanRecord).</param>
+    /// <param name="IsProcessAssigned">Indicates whether the Selector Page has been assigned a Process (True by default).</param>
+    public DataTablePage(string DataTablePath, string PageTitle, Type RecordType, bool IsProcessAssigned = true) 
+    {
+		// instantiate the ViewModel
+        _viewModel = new ViewModels.DataTableViewModel(DataTablePath, PageTitle, RecordType, IsProcessAssigned);
+        BindingContext = _viewModel;
+
+        // create the page from XAML
+		InitializeComponent();
     }
 }

--- a/LotCoMClient/Views/DataTablePage.xaml.cs
+++ b/LotCoMClient/Views/DataTablePage.xaml.cs
@@ -1,5 +1,3 @@
-using LotCoMClient.Models.Options;
-
 namespace LotCoMClient.Views;
 
 /// <summary>
@@ -78,24 +76,15 @@ public partial class DataTablePage : ContentPage
     public async void OnPageLeftFrameCollapseButtonClicked(object sender, EventArgs e) 
     {
         await Task.Delay(0);
-        // the Panel needs to collapse
         if (_viewModel.Options.IsLeftPanelShown) 
         {
-            // set the Left Panel properties in the Page Options
-            _viewModel.Options.IsLeftPanelShown = false;
-            _viewModel.Options.IsLeftPanelHidden = true;
-            _viewModel.Options.LeftPanelWidth = (int)DataTablePageOptions.LeftPanelWidths.Closed;
-            PageLeftFrameCollapseButton.Rotation += 180;
-        // the Panel needs to raise
+            _viewModel.Options.CollapseLeftPanel();
         } 
         else 
         {
-            // set the Left Panel properties in the Page Options
-            _viewModel.Options.IsLeftPanelShown = true;
-            _viewModel.Options.IsLeftPanelHidden = false;
-            _viewModel.Options.LeftPanelWidth = (int)DataTablePageOptions.LeftPanelWidths.Open;
-            PageLeftFrameCollapseButton.Rotation += 180;
+            _viewModel.Options.RaiseLeftPanel();
         }
+        PageLeftFrameCollapseButton.Rotation += 180;
     }
 
     /// <summary>

--- a/LotCoMClient/Views/DataTablePage.xaml.cs
+++ b/LotCoMClient/Views/DataTablePage.xaml.cs
@@ -19,15 +19,13 @@ public partial class DataTablePage : ContentPage
     private readonly DataTablePageOptions _options;
 
     /// <summary>
-    /// Asynchronously evaluates the state of the Data property and sets the BodyTableHeader property accordingly.
-    /// If Data is loaded, shows the Record count. Else, shows "Loading Records...".
+    /// Asynchronously evaluates the state of the Data property and configures the Body Header accordingly.
+    /// If Data is loaded, shows the Navigation Panel. Else, shows "Loading Records...".
     /// </summary>
-    private async Task ConfigureBodyTableHeader() 
+    private async Task ConfigureBodyHeader() 
     {
         await Task.Run(() => 
         {
-            // get the count of Data entries
-            int DataCount;
             // do not do any processing if Data is null (no-Process instantiation)
             if (_viewModel.Data == null) 
             {
@@ -36,21 +34,13 @@ public partial class DataTablePage : ContentPage
             // the Data property is set and is either loading or completed
             if (_viewModel.Data!.IsCompleted && _viewModel.Data.Result != null) 
             {
-                DataCount = _viewModel.Data.Result.Count;
-                // update the BodyTableHeader to show the item count
-                if (DataCount > 1) 
-                {
-                    _options.BodyTableHeaderText = $"Showing {DataCount} records";
-                } 
-                else 
-                {
-                    _options.BodyTableHeaderText = $"Showing {DataCount} records";
-                }
-            // the data is not loaded yet; default BodyTableHeader property
+                // update the BodyTableHeader to show the item count and navigation
+                _options.SetBodyHeaderModeToNavigation();
             } 
             else 
             {
-                _options.BodyTableHeaderText = "Loading records...";
+                // the data is not loaded yet; default Body Table Header options
+                _options.SetBodyHeaderModeToLabel("Loading Records...");
             }
         });
     }
@@ -138,38 +128,20 @@ public partial class DataTablePage : ContentPage
         // the Panel needs to collapse
         if (_options.IsLeftPanelShown) 
         {
-            // set the Left Panel properties in the ViewModel
+            // set the Left Panel properties in the Page Options
             _options.IsLeftPanelShown = false;
             _options.IsLeftPanelHidden = true;
-            // non-animated collapse
             _options.LeftPanelWidth = (int)DataTablePageOptions.LeftPanelWidths.Closed;
             PageLeftFrameCollapseButton.Rotation += 180;
-            // // 12 frame animation (250 -> 30 by increments of 10)
-            // while (_viewModel.LeftFrameWidth > 30) {
-            //     // animate the panel shrinking
-            //     _viewModel.LeftFrameWidth -= 10;
-            //     // animate the collapse button rotating
-            //     PageLeftFrameCollapseButton.Rotation += 15;
-            //     await Task.Delay(1);
-            // }
         // the Panel needs to raise
         } 
         else 
         {
-            // set the Left Panel properties in the ViewModel
+            // set the Left Panel properties in the Page Options
             _options.IsLeftPanelShown = true;
             _options.IsLeftPanelHidden = false;
-            // non-animated raise
             _options.LeftPanelWidth = (int)DataTablePageOptions.LeftPanelWidths.Open;
             PageLeftFrameCollapseButton.Rotation += 180;
-            // // 12 frame animation (30 -> 250 by increments of 10)
-            // while (_viewModel.LeftFrameWidth < 250) {
-            //     // animate the panel raising
-            //     _viewModel.LeftFrameWidth += 10;
-            //     // animate the collapse button rotating
-            //     PageLeftFrameCollapseButton.Rotation += 15;
-            //     await Task.Delay(1);
-            // }
         }
     }
 
@@ -181,7 +153,7 @@ public partial class DataTablePage : ContentPage
     public async void OnPageDataTableListViewPropertyChanged(object sender, EventArgs e) 
     {
         // update BodyTableHeader property
-        await ConfigureBodyTableHeader();
+        await ConfigureBodyHeader();
         await ConfigureDataFields();
     }
 

--- a/LotCoMClient/Views/DataTablePage.xaml.cs
+++ b/LotCoMClient/Views/DataTablePage.xaml.cs
@@ -84,7 +84,7 @@ public partial class DataTablePage : ContentPage
         {
             _viewModel.Options.RaiseLeftPanel();
         }
-        PageLeftFrameCollapseButton.Rotation += 180;
+        LeftPanelCollapseButton.Rotation += 180;
     }
 
     /// <summary>

--- a/LotCoMClient/Views/DataTablePage.xaml.cs
+++ b/LotCoMClient/Views/DataTablePage.xaml.cs
@@ -141,9 +141,9 @@ public partial class DataTablePage : ContentPage
     /// </summary>
     /// <param name="sender"></param>
     /// <param name="e"></param>
-    private async void OnGoToFirstPageButtonClicked(object sender, EventArgs e)
+    private void OnGoToFirstPageButtonClicked(object sender, EventArgs e)
     {
-        await _viewModel.GoToFirstPage();
+        _viewModel.GoToFirstPage();
     }
 
     /// <summary>
@@ -151,9 +151,9 @@ public partial class DataTablePage : ContentPage
     /// </summary>
     /// <param name="sender"></param>
     /// <param name="e"></param>
-    private async void OnGoToPreviousPageButtonClicked(object sender, EventArgs e)
+    private void OnGoToPreviousPageButtonClicked(object sender, EventArgs e)
     {
-        await _viewModel.GoToPreviousPage();
+        _viewModel.GoToPreviousPage();
     }
 
     /// <summary>
@@ -161,9 +161,9 @@ public partial class DataTablePage : ContentPage
     /// </summary>
     /// <param name="sender"></param>
     /// <param name="e"></param>
-    private async void OnGoToNextPageButtonClicked(object sender, EventArgs e)
+    private void OnGoToNextPageButtonClicked(object sender, EventArgs e)
     {
-        await _viewModel.GoToNextPage();
+        _viewModel.GoToNextPage();
     }
 
     /// <summary>
@@ -171,9 +171,9 @@ public partial class DataTablePage : ContentPage
     /// </summary>
     /// <param name="sender"></param>
     /// <param name="e"></param>
-    private async void OnGoToLastPageButtonClicked(object sender, EventArgs e)
+    private void OnGoToLastPageButtonClicked(object sender, EventArgs e)
     {
-        await _viewModel.GoToLastPage();
+        _viewModel.GoToLastPage();
     }
 
     /// <summary>
@@ -181,7 +181,7 @@ public partial class DataTablePage : ContentPage
     /// </summary>
     /// <param name="sender"></param>
     /// <param name="e"></param>
-    private async void OnPageLengthPickerSelectedIndexChanged(object sender, EventArgs e)
+    private void OnPageLengthPickerSelectedIndexChanged(object sender, EventArgs e)
     {
         // get the newly selected PageLength value and update it in the ViewModel
         if (PageLengthPicker is null)
@@ -191,7 +191,7 @@ public partial class DataTablePage : ContentPage
         int PageLength = (int)PageLengthPicker.ItemsSource[_viewModel.Options.SelectedPageLengthIndex]!;
         _viewModel.Options.PageLength = PageLength;
         // refresh the Data Table to use a new PageSet based on the selected PageLength
-        await _viewModel.RefreshPages();
+        _viewModel.RefreshPages();
         _viewModel.ClearFilterOptions();
     }
 

--- a/LotCoMClient/Views/DataTablePage.xaml.cs
+++ b/LotCoMClient/Views/DataTablePage.xaml.cs
@@ -1,4 +1,3 @@
-using LotCoMClient.Models.Datasources;
 using LotCoMClient.Models.Options;
 
 namespace LotCoMClient.Views;
@@ -12,11 +11,6 @@ public partial class DataTablePage : ContentPage
     /// ViewModel object controlling the logic of this Page.
     /// </summary>
 	private readonly ViewModels.DataTableViewModel _viewModel;
-    
-    /// <summary>
-    /// The ViewModel's Options property, exposed for easier access.
-    /// </summary>
-    private readonly DataTablePageOptions _options;
 
     /// <summary>
     /// Asynchronously evaluates the state of the Data property and configures the Body Header accordingly.
@@ -35,12 +29,12 @@ public partial class DataTablePage : ContentPage
             if (_viewModel.Data!.IsCompleted && _viewModel.Data.Result != null) 
             {
                 // update the BodyTableHeader to show the item count and navigation
-                _options.SetBodyHeaderModeToNavigation();
+                _viewModel.Options.SetBodyHeaderModeToNavigation();
             } 
             else 
             {
                 // the data is not loaded yet; default Body Table Header options
-                _options.SetBodyHeaderModeToLabel("Loading Records...");
+                _viewModel.Options.SetBodyHeaderModeToLabel("Loading Records...");
             }
         });
     }
@@ -56,7 +50,7 @@ public partial class DataTablePage : ContentPage
         {
             return;
         }
-        await _options.ConfigurePageFields();
+        await _viewModel.Options.ConfigurePageFields();
     }
 
     /// <summary>
@@ -70,7 +64,6 @@ public partial class DataTablePage : ContentPage
     {
 		// instantiate the ViewModel
         _viewModel = new ViewModels.DataTableViewModel(DataTablePath, PageTitle, RecordType, IsProcessAssigned);
-        _options = _viewModel.Options;
         BindingContext = _viewModel;
 
         // create the page from XAML
@@ -86,21 +79,21 @@ public partial class DataTablePage : ContentPage
     {
         await Task.Delay(0);
         // the Panel needs to collapse
-        if (_options.IsLeftPanelShown) 
+        if (_viewModel.Options.IsLeftPanelShown) 
         {
             // set the Left Panel properties in the Page Options
-            _options.IsLeftPanelShown = false;
-            _options.IsLeftPanelHidden = true;
-            _options.LeftPanelWidth = (int)DataTablePageOptions.LeftPanelWidths.Closed;
+            _viewModel.Options.IsLeftPanelShown = false;
+            _viewModel.Options.IsLeftPanelHidden = true;
+            _viewModel.Options.LeftPanelWidth = (int)DataTablePageOptions.LeftPanelWidths.Closed;
             PageLeftFrameCollapseButton.Rotation += 180;
         // the Panel needs to raise
         } 
         else 
         {
             // set the Left Panel properties in the Page Options
-            _options.IsLeftPanelShown = true;
-            _options.IsLeftPanelHidden = false;
-            _options.LeftPanelWidth = (int)DataTablePageOptions.LeftPanelWidths.Open;
+            _viewModel.Options.IsLeftPanelShown = true;
+            _viewModel.Options.IsLeftPanelHidden = false;
+            _viewModel.Options.LeftPanelWidth = (int)DataTablePageOptions.LeftPanelWidths.Open;
             PageLeftFrameCollapseButton.Rotation += 180;
         }
     }
@@ -127,8 +120,8 @@ public partial class DataTablePage : ContentPage
         await Task.Run(() => 
         {
             // update ViewModel sorting indexes
-            _options.SelectedSortingFieldIndex = ListViewSortingFieldPicker.SelectedIndex;
-            _options.SelectedSortingOrderIndex = ListViewSortingOrderPicker.SelectedIndex;
+            _viewModel.Options.SelectedSortingFieldIndex = ListViewSortingFieldPicker.SelectedIndex;
+            _viewModel.Options.SelectedSortingOrderIndex = ListViewSortingOrderPicker.SelectedIndex;
             // invoke the ViewModel sort method
             _viewModel.SortDataTable();
         });
@@ -144,8 +137,8 @@ public partial class DataTablePage : ContentPage
         await Task.Run(() => 
         {
             // invoke the ViewModel local sort method using the current search term
-            _options.SearchTerm = ListViewSearchingSearchBar.Text;
-            _options.SelectedSearchingFieldIndex = ListViewSearchingFieldPicker.SelectedIndex;
+            _viewModel.Options.SearchTerm = ListViewSearchingSearchBar.Text;
+            _viewModel.Options.SelectedSearchingFieldIndex = ListViewSearchingFieldPicker.SelectedIndex;
             _viewModel.SearchDataTable();
         });
     }

--- a/LotCoMClient/Views/DataTableSelectorPage.xaml
+++ b/LotCoMClient/Views/DataTableSelectorPage.xaml
@@ -352,7 +352,7 @@
                 <Label 
                     x:Name="PageBodyTableHeaderLabel"
                     IsVisible="{Binding Options.IsBodyHeaderLabelShown}"
-                    Text="{Binding Options.BodyTableHeaderText}"
+                    Text="{Binding Options.BodyHeaderText}"
                     TextColor="{AppThemeBinding Light={StaticResource Black}, Dark={StaticResource White}}"
                     FontAttributes="None"
                     FontSize="16"
@@ -402,7 +402,7 @@
                         Grid.Row="0"
                         Grid.RowSpan="2"
                         Grid.Column="3"
-                        SelectedIndex="{Binding Options.SelectedShownRecordCountIndex}"
+                        SelectedIndex="{Binding Options.SelectedPageLengthIndex}"
                         Margin="0,0,0,2"
                         HorizontalOptions="Center"
                         VerticalOptions="End">

--- a/LotCoMClient/Views/DataTableSelectorPage.xaml
+++ b/LotCoMClient/Views/DataTableSelectorPage.xaml
@@ -394,10 +394,11 @@
                     <!-- Page Length (Shown Record Number) Picker -->
                     <Picker
                         x:Name="PageLengthPicker"
+                        SelectedIndex="{Binding Options.SelectedPageLengthIndex}"
+                        SelectedIndexChanged="OnPageLengthPickerSelectedIndexChanged"
                         Grid.Row="0"
                         Grid.RowSpan="2"
                         Grid.Column="3"
-                        SelectedIndex="{Binding Options.SelectedPageLengthIndex}"
                         Margin="0,0,0,2"
                         HorizontalOptions="Center"
                         VerticalOptions="End">

--- a/LotCoMClient/Views/DataTableSelectorPage.xaml
+++ b/LotCoMClient/Views/DataTableSelectorPage.xaml
@@ -423,7 +423,7 @@
                         Grid.Column="4"
                         Grid.ColumnSpan="3"
                         Margin="5,0,5,0"
-                        Text="{Binding Options.TotalRecordCount, StringFormat='of {0} records'}"
+                        Text="{Binding Data.Result.Count, StringFormat='of {0} records'}"
                         TextColor="{AppThemeBinding Light={StaticResource PrimaryText}, Dark={StaticResource PrimaryTextDark}}"
                         FontSize="16"
                         HorizontalOptions="Start"

--- a/LotCoMClient/Views/DataTableSelectorPage.xaml
+++ b/LotCoMClient/Views/DataTableSelectorPage.xaml
@@ -489,7 +489,7 @@
                     <Label
                         Grid.Row="2"
                         Grid.Column="3"
-                        Text="Page #"
+                        Text="{Binding PageNumberContext}"
                         HorizontalOptions="Center"
                         VerticalOptions="Center"/>
                     <!-- Older Button (forward to next) -->

--- a/LotCoMClient/Views/DataTableSelectorPage.xaml
+++ b/LotCoMClient/Views/DataTableSelectorPage.xaml
@@ -452,7 +452,7 @@
                         Grid.Column="4"
                         Grid.ColumnSpan="3"
                         Margin="5,0,5,0"
-                        Text="{Binding Table.RecordCount, StringFormat='of {0} records'}"
+                        Text="{Binding Table.ActivePageSet.EntryCount, StringFormat='of {0} records'}"
                         TextColor="{AppThemeBinding Light={StaticResource PrimaryText}, Dark={StaticResource PrimaryTextDark}}"
                         FontSize="16"
                         HorizontalOptions="Start"

--- a/LotCoMClient/Views/DataTableSelectorPage.xaml
+++ b/LotCoMClient/Views/DataTableSelectorPage.xaml
@@ -423,7 +423,7 @@
                         Grid.Column="4"
                         Grid.ColumnSpan="3"
                         Margin="5,0,5,0"
-                        Text="{Binding Data.Result.Count, StringFormat='of {0} records'}"
+                        Text="{Binding Table.RecordCount, StringFormat='of {0} records'}"
                         TextColor="{AppThemeBinding Light={StaticResource PrimaryText}, Dark={StaticResource PrimaryTextDark}}"
                         FontSize="16"
                         HorizontalOptions="Start"
@@ -490,9 +490,9 @@
             <!-- Activity Indicator (Shows While Loading Data) -->
             <ActivityIndicator 
                 x:Name="PageDataLoadingActivityIndicator"
-                IsEnabled="{Binding Data.IsNotCompleted}"
-                IsVisible="{Binding Data.IsNotCompleted}"
-                IsRunning="{Binding Data.IsNotCompleted}"
+                IsEnabled="{Binding CurrentPage.IsNotCompleted}"
+                IsVisible="{Binding CurrentPage.IsNotCompleted}"
+                IsRunning="{Binding CurrentPage.IsNotCompleted}"
                 Grid.Row="1"
                 Grid.Column="0"
                 Color="{StaticResource Secondary}"
@@ -501,13 +501,13 @@
             <!-- Actual View -->
             <ScrollView
                 x:Name="PageBodyTableScrollView"
-                IsVisible="{Binding Data.IsCompleted}"
+                IsVisible="{Binding CurrentPage.IsCompleted}"
                 Grid.Row="1"
                 Grid.Column="0">
                 <!-- Page Data Table List View -->
                 <ListView
                     x:Name="PageDataTableListView"
-                    ItemsSource="{Binding Data.Result}"
+                    ItemsSource="{Binding CurrentPage.Result.DataRecords}"
                     PropertyChanged="OnPageDataTableListViewPropertyChanged"
                     Margin="20">
                     <!-- Configure DataRecord ItemTemplate -->

--- a/LotCoMClient/Views/DataTableSelectorPage.xaml
+++ b/LotCoMClient/Views/DataTableSelectorPage.xaml
@@ -349,17 +349,20 @@
                 Grid.Column="0"
                 Grid.ColumnSpan="1">
                 <!-- Page Body Table Header Label -->
-                <!-- <Label 
+                <Label 
                     x:Name="PageBodyTableHeaderLabel"
+                    IsVisible="{Binding Options.IsBodyHeaderLabelShown}"
                     Text="{Binding Options.BodyTableHeaderText}"
                     TextColor="{AppThemeBinding Light={StaticResource Black}, Dark={StaticResource White}}"
                     FontAttributes="None"
                     FontSize="16"
                     Margin="22,20,20,20"
                     HorizontalOptions="Start"
-                    VerticalOptions="Center"/> -->
+                    VerticalOptions="Center"/>
                 <!-- Page Navigation Control Grid -->
-                <Grid>
+                <Grid
+                    x:Name="BodyHeaderNavigationPanel"
+                    IsVisible="{Binding Options.IsBodyNavigationPanelShown}">
                     <Grid.RowDefinitions>
                         <!-- Padding Row -->
                         <RowDefinition Height="10"/>
@@ -399,17 +402,18 @@
                         Grid.Row="0"
                         Grid.RowSpan="2"
                         Grid.Column="3"
+                        SelectedIndex="{Binding Options.SelectedShownRecordCountIndex}"
                         Margin="0,0,0,2"
                         HorizontalOptions="Center"
                         VerticalOptions="End">
                         <Picker.ItemsSource>
-                            <x:Array Type="{x:Type x:Int16}">
-                                <x:Int16>15</x:Int16>
-                                <x:Int16>25</x:Int16>
-                                <x:Int16>35</x:Int16>
-                                <x:Int16>50</x:Int16>
-                                <x:Int16>75</x:Int16>
-                                <x:Int16>100</x:Int16>
+                            <x:Array Type="{x:Type x:Int32}">
+                                <x:Int32>15</x:Int32>
+                                <x:Int32>25</x:Int32>
+                                <x:Int32>35</x:Int32>
+                                <x:Int32>50</x:Int32>
+                                <x:Int32>75</x:Int32>
+                                <x:Int32>100</x:Int32>
                             </x:Array>
                         </Picker.ItemsSource>
                     </Picker>
@@ -419,7 +423,7 @@
                         Grid.Column="4"
                         Grid.ColumnSpan="3"
                         Margin="5,0,5,0"
-                        Text="of [Record #] records"
+                        Text="{Binding Options.TotalRecordCount, StringFormat='of {0} records'}"
                         TextColor="{AppThemeBinding Light={StaticResource PrimaryText}, Dark={StaticResource PrimaryTextDark}}"
                         FontSize="16"
                         HorizontalOptions="Start"
@@ -481,19 +485,6 @@
                         VerticalOptions="Center"/>
                 </Grid>
             </HorizontalStackLayout>
-
-            <!-- Page Body Table Header Label -->
-            <Label 
-                x:Name="PageBodyTableHeaderLabel"
-                Text="{Binding Options.BodyTableHeaderText}"
-                Grid.Row="0"
-                Grid.Column="0"
-                TextColor="{AppThemeBinding Light={StaticResource Black}, Dark={StaticResource White}}"
-                FontAttributes="None"
-                FontSize="16"
-                Margin="22,20,20,20"
-                HorizontalOptions="Start"
-                VerticalOptions="Center"/>
                 
             <!-- Page Body Table ScrollView -->
             <!-- Activity Indicator (Shows While Loading Data) -->

--- a/LotCoMClient/Views/DataTableSelectorPage.xaml
+++ b/LotCoMClient/Views/DataTableSelectorPage.xaml
@@ -121,8 +121,7 @@
                     Grid.Column="0"
                     IsVisible="{Binding Options.IsLeftPanelShown}">
                     <!-- Body ScrollView Sub-Grid (allows layout customization) -->
-                    <Grid
-                        IsVisible="{Binding Options.IsProcessAssigned}">
+                    <Grid>
                         <Grid.RowDefinitions>
                             <!-- ListView Sorting Label Row -->
                             <RowDefinition Height="Auto"/>
@@ -130,11 +129,15 @@
                             <RowDefinition Height="Auto"/>
                             <!-- ListView Sorting Order Picker Row -->
                             <RowDefinition Height="Auto"/>
+                            <!-- ListView Sorting Clear Button Row -->
+                            <RowDefinition Height="Auto"/>
                             <!-- ListView Searching Label Row -->
                             <RowDefinition Height="Auto"/>
                             <!-- ListView Searching SearchBar Row -->
                             <RowDefinition Height="Auto"/>
                             <!-- ListView Searching Field Picker Row -->
+                            <RowDefinition Height="Auto"/>
+                            <!-- ListView Searching Clear Button Row -->
                             <RowDefinition Height="Auto"/>
                             <!-- Expand Rows to Add Frame Entries -->
                             <RowDefinition Height="*"/>
@@ -201,9 +204,23 @@
                                 </x:Array>
                             </Picker.ItemsSource>
                         </Picker>
+                        <!-- ListView Sort Clear Button -->
+                        <Button 
+                            x:Name="ListViewSortingClearButton"
+                            Clicked="OnListViewFilterClearButtonClicked"
+                            Grid.Row="3"
+                            Grid.Column="0"
+                            Text="Reset"
+                            FontSize="10"
+                            Margin="11,0,0,12"
+                            CornerRadius="3"
+                            WidthRequest="65"
+                            HeightRequest="30"
+                            HorizontalOptions="Start"
+                            VerticalOptions="Center"/>
                         <!-- Sorting Panel Lower Border BoxView -->
                         <BoxView
-                            Grid.Row="2"
+                            Grid.Row="3"
                             Grid.Column="0"
                             Margin="0,0,1,0"
                             HorizontalOptions="Fill"
@@ -212,8 +229,7 @@
                             BackgroundColor="{AppThemeBinding Light={StaticResource Foreground}, Dark={StaticResource ForegroundDark}}"/>
                         <!-- Searching Panel Upper Border BoxView -->
                         <BoxView
-                            IsVisible="{Binding Options.IsProcessAssigned}"
-                            Grid.Row="3"
+                            Grid.Row="4"
                             Grid.Column="0"
                             Margin="0,0,1,0"
                             HorizontalOptions="Fill"
@@ -222,7 +238,7 @@
                             BackgroundColor="{AppThemeBinding Light={StaticResource Foreground}, Dark={StaticResource ForegroundDark}}"/>
                         <!-- ListView Searching Label -->
                         <Label 
-                            Grid.Row="3"
+                            Grid.Row="4"
                             Grid.Column="0"
                             Text="Search Records"
                             TextColor="{AppThemeBinding Light={StaticResource SecondaryText}, Dark={StaticResource SecondaryTextDark}}"
@@ -236,7 +252,7 @@
                             x:Name="ListViewSearchingSearchBar"
                             SearchButtonPressed="OnListViewSearchButtonPressed"
                             Text="{Binding Options.SearchTerm}"
-                            Grid.Row="4"
+                            Grid.Row="5"
                             Grid.Column="0"
                             Margin="10"
                             FontSize="10"
@@ -248,7 +264,7 @@
                             x:Name="ListViewSearchingFieldPicker"
                             SelectedIndex="{Binding Options.SelectedSearchingFieldIndex}"
                             SelectedItem="All"
-                            Grid.Row="5"
+                            Grid.Row="6"
                             Grid.Column="0"
                             Margin="10"
                             Title="Search field"
@@ -258,9 +274,23 @@
                             HeightRequest="65"
                             HorizontalOptions="Start"
                             VerticalOptions="Center"/>
+                        <!-- ListView Search Clear Button -->
+                        <Button 
+                            x:Name="ListViewSearchingClearButton"
+                            Clicked="OnListViewFilterClearButtonClicked"
+                            Grid.Row="7"
+                            Grid.Column="0"
+                            Text="Clear"
+                            FontSize="10"
+                            Margin="11,0,0,12"
+                            CornerRadius="3"
+                            WidthRequest="65"
+                            HeightRequest="30"
+                            HorizontalOptions="Start"
+                            VerticalOptions="Center"/>
                         <!-- Searching Panel Lower Border BoxView -->
                         <BoxView
-                            Grid.Row="5"
+                            Grid.Row="7"
                             Grid.Column="0"
                             Margin="0,0,1,0"
                             HorizontalOptions="Fill"

--- a/LotCoMClient/Views/DataTableSelectorPage.xaml
+++ b/LotCoMClient/Views/DataTableSelectorPage.xaml
@@ -566,11 +566,15 @@
                                         <!-- Left-Side Padding Column -->
                                         <ColumnDefinition Width="25"/>
                                         <!-- Date Column -->
-                                        <ColumnDefinition Width="125"/>
+                                        <ColumnDefinition Width="Auto"/>
                                         <!-- Time Column -->
-                                        <ColumnDefinition Width="125"/>
+                                        <ColumnDefinition Width="Auto"/>
+                                        <!-- ScanRecord Scanner Address Column -->
+                                        <ColumnDefinition Width="Auto"/>
+                                        <!-- ScanRecord Production Timestamp Column -->
+                                        <ColumnDefinition Width="Auto"/>
                                         <!-- Shift Column -->
-                                        <ColumnDefinition Width="125"/>
+                                        <ColumnDefinition Width="Auto"/>
                                         <!-- Operator Column -->
                                         <ColumnDefinition Width="*"/>
                                     </Grid.ColumnDefinitions>
@@ -579,7 +583,7 @@
                                         Margin="0,10,0,0"
                                         Grid.Row="0"
                                         Grid.Column="1"
-                                        Grid.ColumnSpan="4">
+                                        Grid.ColumnSpan="6">
                                         <!-- DataRecord Part Number -->
                                         <Label
                                             Text="{Binding RecordPart.PartNumber, StringFormat='Part: {0}'}"
@@ -658,21 +662,41 @@
                                         FontSize="12"
                                         TextColor="{StaticResource Gray500}"
                                         VerticalOptions="Start"/>
-                                    <!-- DataRecord Shift Label -->
+                                    <!-- ScanRecord Scanner Address Label -->
                                     <Label
-                                        Margin="5,0,0,0"
+                                        Margin="20,0,0,0"
+                                        IsVisible="{Binding IsScanRecord}"
                                         Grid.Row="1"
                                         Grid.Column="3"
+                                        Text="{Binding ScanAddress, StringFormat='Scanner: {0}'}"
+                                        FontSize="12"
+                                        TextColor="{StaticResource Gray500}"
+                                        VerticalOptions="Start"/>
+                                    <!-- ScanRecord Production Timestamp -->
+                                    <Label 
+                                        Margin="20,0,0,0"
+                                        IsVisible="{Binding IsScanRecord}"
+                                        Grid.Row="1"
+                                        Grid.Column="4"
+                                        Text="{Binding ProductionTimestamp, StringFormat='Produced: {0}'}"
+                                        FontSize="12"
+                                        TextColor="{StaticResource Gray500}"
+                                        VerticalOptions="Start"/>
+                                    <!-- DataRecord Shift Label -->
+                                    <Label
+                                        Margin="10,0,0,0"
+                                        Grid.Row="1"
+                                        Grid.Column="5"
                                         Text="{Binding RecordShift, StringFormat='Shift: {0}'}"
                                         FontSize="12"
                                         TextColor="{StaticResource Gray500}"
                                         VerticalOptions="Start"/>
-                                    <!-- DataRecord Operator Label -->
-                                    <Label
-                                        Margin="5,0,0,0"
+                                    <!-- DataRecord Production Operator -->
+                                    <Label 
+                                        Margin="10,0,0,0"
                                         Grid.Row="1"
-                                        Grid.Column="4"
-                                        Text="{Binding OperatorID, StringFormat='ID: {0}'}"
+                                        Grid.Column="6"
+                                        Text="{Binding OperatorID, StringFormat='Operator: {0}'}"
                                         FontSize="12"
                                         TextColor="{StaticResource Gray500}"
                                         VerticalOptions="Start"/>
@@ -680,7 +704,7 @@
                                     <BoxView
                                         Grid.Row="2"
                                         Grid.Column="0"
-                                        Grid.ColumnSpan="5"
+                                        Grid.ColumnSpan="7"
                                         HeightRequest="1"
                                         HorizontalOptions="Fill"
                                         VerticalOptions="Center"

--- a/LotCoMClient/Views/DataTableSelectorPage.xaml
+++ b/LotCoMClient/Views/DataTableSelectorPage.xaml
@@ -343,6 +343,145 @@
                 <ColumnDefinition Width="*"/>
             </Grid.ColumnDefinitions>
 
+            <!-- Horizontal Layout For Body Table Header and Page Navigation Controls -->
+            <HorizontalStackLayout
+                Grid.Row="0"
+                Grid.Column="0"
+                Grid.ColumnSpan="1">
+                <!-- Page Body Table Header Label -->
+                <!-- <Label 
+                    x:Name="PageBodyTableHeaderLabel"
+                    Text="{Binding Options.BodyTableHeaderText}"
+                    TextColor="{AppThemeBinding Light={StaticResource Black}, Dark={StaticResource White}}"
+                    FontAttributes="None"
+                    FontSize="16"
+                    Margin="22,20,20,20"
+                    HorizontalOptions="Start"
+                    VerticalOptions="Center"/> -->
+                <!-- Page Navigation Control Grid -->
+                <Grid>
+                    <Grid.RowDefinitions>
+                        <!-- Padding Row -->
+                        <RowDefinition Height="10"/>
+                        <!-- Showing Records Number Row -->
+                        <RowDefinition Height="50"/>
+                        <!-- Page Number Control Row -->
+                        <RowDefinition Height="40"/>
+                    </Grid.RowDefinitions>
+                    <Grid.ColumnDefinitions>
+                        <!-- Padding Column -->
+                        <ColumnDefinition Width="20"/>
+                        <!-- Newer Records (Back) Page Navigation Controls Columns -->
+                        <ColumnDefinition Width="40"/>
+                        <ColumnDefinition Width="40"/>
+                        <!-- Page Number Label Columns -->
+                        <ColumnDefinition Width="75"/>
+                        <!-- Older Records (Forward) Page Navigation Controls Columns -->
+                        <ColumnDefinition Width="40"/>
+                        <ColumnDefinition Width="40"/>
+                        <!-- "of [Record Number] records" Label Extension Column -->
+                        <ColumnDefinition Width="Auto"/>
+                    </Grid.ColumnDefinitions>
+                    <!-- "Showing" Label -->
+                    <Label 
+                        Grid.Row="1"
+                        Grid.Column="1"
+                        Grid.ColumnSpan="2"
+                        Margin="5,0,5,0"
+                        Text="Showing"
+                        TextColor="{AppThemeBinding Light={StaticResource PrimaryText}, Dark={StaticResource PrimaryTextDark}}"
+                        FontSize="16"
+                        HorizontalOptions="Center"
+                        VerticalOptions="Center"/>
+                    <!-- Shown Record Count Picker -->
+                    <Picker
+                        x:Name="ShownRecordCountPicker"
+                        Grid.Row="0"
+                        Grid.RowSpan="2"
+                        Grid.Column="3"
+                        Margin="0,0,0,2"
+                        HorizontalOptions="Center"
+                        VerticalOptions="End">
+                        <Picker.ItemsSource>
+                            <x:Array Type="{x:Type x:Int16}">
+                                <x:Int16>15</x:Int16>
+                                <x:Int16>25</x:Int16>
+                                <x:Int16>35</x:Int16>
+                                <x:Int16>50</x:Int16>
+                                <x:Int16>75</x:Int16>
+                                <x:Int16>100</x:Int16>
+                            </x:Array>
+                        </Picker.ItemsSource>
+                    </Picker>
+                    <!-- "Of <Record Count>" Label -->
+                    <Label 
+                        Grid.Row="1"
+                        Grid.Column="4"
+                        Grid.ColumnSpan="3"
+                        Margin="5,0,5,0"
+                        Text="of [Record #] records"
+                        TextColor="{AppThemeBinding Light={StaticResource PrimaryText}, Dark={StaticResource PrimaryTextDark}}"
+                        FontSize="16"
+                        HorizontalOptions="Start"
+                        VerticalOptions="Center"/>
+                    <!-- Newest Button (back to start) -->
+                    <Button 
+                        Grid.Row="2"
+                        Grid.Column="1"
+                        Padding="10"
+                        WidthRequest="15"
+                        HeightRequest="15"
+                        CornerRadius="100"
+                        BackgroundColor="Transparent"
+                        ImageSource="{AppThemeBinding Light=left_arrow_black.png, Dark=left_arrow_white.png}"
+                        HorizontalOptions="Center"
+                        VerticalOptions="Center"/>
+                    <!-- Newer Button (back to previous) -->
+                    <Button 
+                        Grid.Row="2"
+                        Grid.Column="2"
+                        Padding="10"
+                        WidthRequest="15"
+                        HeightRequest="15"
+                        CornerRadius="100"
+                        BackgroundColor="Transparent"
+                        ImageSource="{AppThemeBinding Light=left_arrow_black.png, Dark=left_arrow_white.png}"
+                        HorizontalOptions="Center"
+                        VerticalOptions="Center"/>
+                    <!-- Page Number Label -->
+                    <Label
+                        Grid.Row="2"
+                        Grid.Column="3"
+                        Text="Page #"
+                        HorizontalOptions="Center"
+                        VerticalOptions="Center"/>
+                    <!-- Older Button (forward to next) -->
+                    <Button 
+                        Grid.Row="2"
+                        Grid.Column="4"
+                        Padding="10"
+                        WidthRequest="15"
+                        HeightRequest="15"
+                        CornerRadius="100"
+                        BackgroundColor="Transparent"
+                        ImageSource="{AppThemeBinding Light=right_arrow_black.png, Dark=right_arrow_white.png}"
+                        HorizontalOptions="Center"
+                        VerticalOptions="Center"/>
+                    <!-- Oldest Button (forward to end) -->
+                    <Button 
+                        Grid.Row="2"
+                        Grid.Column="5"
+                        Padding="10"
+                        WidthRequest="15"
+                        HeightRequest="15"
+                        CornerRadius="100"
+                        BackgroundColor="Transparent"
+                        ImageSource="{AppThemeBinding Light=right_arrow_black.png, Dark=right_arrow_white.png}"
+                        HorizontalOptions="Center"
+                        VerticalOptions="Center"/>
+                </Grid>
+            </HorizontalStackLayout>
+
             <!-- Page Body Table Header Label -->
             <Label 
                 x:Name="PageBodyTableHeaderLabel"

--- a/LotCoMClient/Views/DataTableSelectorPage.xaml
+++ b/LotCoMClient/Views/DataTableSelectorPage.xaml
@@ -168,6 +168,7 @@
                         <!-- ListView Sorting Field Picker -->
                         <Picker
                             x:Name="ListViewSortingFieldPicker"
+                            SelectedIndex="{Binding Options.SelectedSortingFieldIndex}"
                             SelectedIndexChanged="OnSortParameterSelectedIndexChanged"
                             Grid.Row="1"
                             Grid.Column="0"
@@ -182,6 +183,7 @@
                         <!-- ListView Sorting Order Picker -->
                         <Picker
                             x:Name="ListViewSortingOrderPicker"
+                            SelectedIndex="{Binding Options.SelectedSortingOrderIndex}"
                             SelectedIndexChanged="OnSortParameterSelectedIndexChanged"
                             Grid.Row="2"
                             Grid.Column="0"
@@ -245,6 +247,7 @@
                         <Picker
                             x:Name="ListViewSearchingFieldPicker"
                             SelectedIndex="{Binding Options.SelectedSearchingFieldIndex}"
+                            SelectedItem="All"
                             Grid.Row="5"
                             Grid.Column="0"
                             Margin="10"

--- a/LotCoMClient/Views/DataTableSelectorPage.xaml
+++ b/LotCoMClient/Views/DataTableSelectorPage.xaml
@@ -34,14 +34,14 @@
         <!-- Title Frame -->
         <!-- Top-Left Page Corner Frame -->
         <BoxView
-            x:Name="PageTopLeftCornerFrameFill"
+            x:Name="TopLeftCornerFrameFill"
             Grid.Row="0"
             Grid.Column="0"
             WidthRequest="{Binding Options.LeftPanelWidth}"
             BackgroundColor="{AppThemeBinding Light={StaticResource Framing}, Dark={StaticResource FramingDark}}"/>
         <!-- Title Frame -->
         <VerticalStackLayout
-            x:Name="PageTitleFrameLayout"
+            x:Name="TitleFrameLayout"
             Grid.Row="0"
             Grid.Column="1"
             Margin="0"
@@ -50,7 +50,7 @@
             <HorizontalStackLayout>
                 <!-- Title Label -->
                 <Label
-                    x:Name="PageTitleFrameLabel"
+                    x:Name="TitleFrameLabel"
                     Text="{Binding Options.Title}"
                     TextColor="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}"
                     FontAttributes="None"
@@ -69,7 +69,7 @@
                     VerticalOptions="Center"/>
                 <!-- Process Selector -->
                 <Picker
-                    x:Name="PageProcessPicker"
+                    x:Name="ProcessPicker"
                     ItemsSource="{Binding Options.DepartmentProcesses}"
                     ItemDisplayBinding="{Binding FullName}"
                     SelectedIndexChanged="OnPageProcessSelectionChanged"
@@ -85,16 +85,16 @@
             </HorizontalStackLayout>
             <!-- Title Frame Bottom Border -->
             <BoxView
-                x:Name="PageTitleFrameBottomBorder"
+                x:Name="TitleFrameBottomBorder"
                 HeightRequest="1"
                 HorizontalOptions="Fill"
                 VerticalOptions="End"
                 BackgroundColor="{AppThemeBinding Light={StaticResource Foreground}, Dark={StaticResource ForegroundDark}}"/>
         </VerticalStackLayout>
 
-        <!-- Left-Side Frame -->
+        <!-- Left Panel -->
         <HorizontalStackLayout
-            x:Name="PageLeftFrameLayout"
+            x:Name="LeftPanelLayout"
             Grid.Row="1"
             Grid.Column="0"
             Margin="0"
@@ -121,7 +121,8 @@
                     Grid.Column="0"
                     IsVisible="{Binding Options.IsLeftPanelShown}">
                     <!-- Body ScrollView Sub-Grid (allows layout customization) -->
-                    <Grid>
+                    <Grid
+                        IsVisible="{Binding Options.IsProcessAssigned}">
                         <Grid.RowDefinitions>
                             <!-- ListView Sorting Label Row -->
                             <RowDefinition Height="Auto"/>
@@ -146,7 +147,6 @@
                         <!-- Add ScrollView Entries Here -->
                         <!-- Sorting Panel Upper Border BoxView -->
                         <BoxView
-                            IsVisible="{Binding Options.IsProcessAssigned}"
                             Grid.Row="0"
                             Grid.Column="0"
                             Margin="0,0,1,0"
@@ -156,7 +156,6 @@
                             BackgroundColor="{AppThemeBinding Light={StaticResource Foreground}, Dark={StaticResource ForegroundDark}}"/>
                         <!-- ListView Sorting Label -->
                         <Label 
-                            IsVisible="{Binding Options.IsProcessAssigned}"
                             Grid.Row="0"
                             Grid.Column="0"
                             Text="Sort Records"
@@ -170,7 +169,6 @@
                         <Picker
                             x:Name="ListViewSortingFieldPicker"
                             SelectedIndexChanged="OnSortParameterSelectedIndexChanged"
-                            IsVisible="{Binding Options.IsProcessAssigned}"
                             Grid.Row="1"
                             Grid.Column="0"
                             Margin="10"
@@ -185,7 +183,6 @@
                         <Picker
                             x:Name="ListViewSortingOrderPicker"
                             SelectedIndexChanged="OnSortParameterSelectedIndexChanged"
-                            IsVisible="{Binding Options.IsProcessAssigned}"
                             Grid.Row="2"
                             Grid.Column="0"
                             Margin="10"
@@ -204,7 +201,6 @@
                         </Picker>
                         <!-- Sorting Panel Lower Border BoxView -->
                         <BoxView
-                            IsVisible="{Binding Options.IsProcessAssigned}"
                             Grid.Row="2"
                             Grid.Column="0"
                             Margin="0,0,1,0"
@@ -224,7 +220,6 @@
                             BackgroundColor="{AppThemeBinding Light={StaticResource Foreground}, Dark={StaticResource ForegroundDark}}"/>
                         <!-- ListView Searching Label -->
                         <Label 
-                            IsVisible="{Binding Options.IsProcessAssigned}"
                             Grid.Row="3"
                             Grid.Column="0"
                             Text="Search Records"
@@ -272,9 +267,9 @@
                     </Grid>
                 </ScrollView>
 
-                <!-- Left Frame Footer Label -->
+                <!-- Left Panel Footer Label -->
                 <Label 
-                    x:Name="PageLeftFrameFooterLabel"
+                    x:Name="LeftPanelFooterLabel"
                     IsVisible="{Binding Options.IsLeftPanelShown}"
                     Margin="10,0,0,15"
                     Grid.Row="2"
@@ -287,7 +282,7 @@
                 
                 <!-- Panel Collapse Button -->
                 <Button
-                    x:Name="PageLeftFrameCollapseButton"
+                    x:Name="LeftPanelCollapseButton"
                     Clicked="OnPageLeftFrameCollapseButtonClicked"
                     Margin="-14,10,1,0"
                     Padding="10"
@@ -300,9 +295,9 @@
                     CornerRadius="30"
                     ImageSource="{AppThemeBinding Light=left_arrow_black.png, Dark=left_arrow_white.png}"/>
 
-                <!-- Left Frame Right Border -->
+                <!-- Left Panel Right Border -->
                 <BoxView
-                    x:Name="PageLeftFrameRightBorder"
+                    x:Name="LeftPanelRightBorder"
                     IsVisible="true"
                     Grid.Row="0"
                     Grid.RowSpan="3"
@@ -310,13 +305,13 @@
                     WidthRequest="1"
                     HorizontalOptions="End"
                     VerticalOptions="Fill"
-                    BackgroundColor="{AppThemeBinding Light={StaticResource Foreground}, Dark={StaticResource Gray600}}"/>
+                    BackgroundColor="{AppThemeBinding Light={StaticResource Foreground}, Dark={StaticResource ForegroundDark}}"/>
             </Grid>
         </HorizontalStackLayout>
 
-        <!-- Left Frame Header Label (Defined outside of frame for positioning) -->
+        <!-- Left Panel Header Label (Defined outside of Panel for positioning) -->
         <Label 
-            x:Name="PageLeftFrameHeaderLabel"
+            x:Name="LeftPanelHeaderLabel"
             IsVisible="{Binding Options.IsLeftPanelShown}"
             Margin="0"
             Grid.Row="0"
@@ -343,14 +338,14 @@
                 <ColumnDefinition Width="*"/>
             </Grid.ColumnDefinitions>
 
-            <!-- Horizontal Layout For Body Table Header and Page Navigation Controls -->
+            <!-- Horizontal Layout For Body Header and Page Navigation Controls -->
             <HorizontalStackLayout
                 Grid.Row="0"
                 Grid.Column="0"
                 Grid.ColumnSpan="1">
-                <!-- Page Body Table Header Label -->
+                <!-- Page Body Header Label -->
                 <Label 
-                    x:Name="PageBodyTableHeaderLabel"
+                    x:Name="BodyHeaderLabel"
                     IsVisible="{Binding Options.IsBodyHeaderLabelShown}"
                     Text="{Binding Options.BodyHeaderText}"
                     TextColor="{AppThemeBinding Light={StaticResource Black}, Dark={StaticResource White}}"
@@ -396,9 +391,9 @@
                         FontSize="16"
                         HorizontalOptions="Center"
                         VerticalOptions="Center"/>
-                    <!-- Shown Record Count Picker -->
+                    <!-- Page Length (Shown Record Number) Picker -->
                     <Picker
-                        x:Name="ShownRecordCountPicker"
+                        x:Name="PageLengthPicker"
                         Grid.Row="0"
                         Grid.RowSpan="2"
                         Grid.Column="3"
@@ -430,6 +425,8 @@
                         VerticalOptions="Center"/>
                     <!-- Newest Button (back to start) -->
                     <Button 
+                        x:Name="GoToFirstPageButton"
+                        Clicked="OnGoToFirstPageButtonClicked"
                         Grid.Row="2"
                         Grid.Column="1"
                         Padding="10"
@@ -442,6 +439,8 @@
                         VerticalOptions="Center"/>
                     <!-- Newer Button (back to previous) -->
                     <Button 
+                        x:Name="GoToPreviousPageButton"
+                        Clicked="OnGoToPreviousPageButtonClicked"
                         Grid.Row="2"
                         Grid.Column="2"
                         Padding="10"
@@ -461,6 +460,8 @@
                         VerticalOptions="Center"/>
                     <!-- Older Button (forward to next) -->
                     <Button 
+                        x:Name="GoToNextPageButton"
+                        Clicked="OnGoToNextPageButtonClicked"
                         Grid.Row="2"
                         Grid.Column="4"
                         Padding="10"
@@ -473,6 +474,8 @@
                         VerticalOptions="Center"/>
                     <!-- Oldest Button (forward to end) -->
                     <Button 
+                        x:Name="GoToLastPageButton"
+                        Clicked="OnGoToLastPageButtonClicked"
                         Grid.Row="2"
                         Grid.Column="5"
                         Padding="10"
@@ -486,10 +489,10 @@
                 </Grid>
             </HorizontalStackLayout>
                 
-            <!-- Page Body Table ScrollView -->
+            <!-- Page Body ScrollView -->
             <!-- Activity Indicator (Shows While Loading Data) -->
             <ActivityIndicator 
-                x:Name="PageDataLoadingActivityIndicator"
+                x:Name="DataLoadingActivityIndicator"
                 IsEnabled="{Binding CurrentPage.IsNotCompleted}"
                 IsVisible="{Binding CurrentPage.IsNotCompleted}"
                 IsRunning="{Binding CurrentPage.IsNotCompleted}"
@@ -500,13 +503,13 @@
                 HeightRequest="200"/>
             <!-- Actual View -->
             <ScrollView
-                x:Name="PageBodyTableScrollView"
+                x:Name="BodyScrollView"
                 IsVisible="{Binding CurrentPage.IsCompleted}"
                 Grid.Row="1"
                 Grid.Column="0">
                 <!-- Page Data Table List View -->
                 <ListView
-                    x:Name="PageDataTableListView"
+                    x:Name="DataTableListView"
                     ItemsSource="{Binding CurrentPage.Result.DataRecords}"
                     PropertyChanged="OnPageDataTableListViewPropertyChanged"
                     Margin="20">

--- a/LotCoMClient/Views/DataTableSelectorPage.xaml.cs
+++ b/LotCoMClient/Views/DataTableSelectorPage.xaml.cs
@@ -132,7 +132,7 @@ public partial class DataTableSelectorPage : ContentPage
     }
 
     /// <summary>
-    /// Handler for the Clicked event from the OnGoToFirstPageButtonClicked control.
+    /// Handler for the Clicked event from the OnGoToFirstPageButton control.
     /// </summary>
     /// <param name="sender"></param>
     /// <param name="e"></param>
@@ -142,7 +142,7 @@ public partial class DataTableSelectorPage : ContentPage
     }
 
     /// <summary>
-    /// Handler for the Clicked event from the OnGoToPreviousPageButtonClicked control.
+    /// Handler for the Clicked event from the OnGoToPreviousPageButton control.
     /// </summary>
     /// <param name="sender"></param>
     /// <param name="e"></param>
@@ -152,7 +152,7 @@ public partial class DataTableSelectorPage : ContentPage
     }
 
     /// <summary>
-    /// Handler for the Clicked event from the OnGoToNextPageButtonClicked control.
+    /// Handler for the Clicked event from the OnGoToNextPageButton control.
     /// </summary>
     /// <param name="sender"></param>
     /// <param name="e"></param>
@@ -162,13 +162,31 @@ public partial class DataTableSelectorPage : ContentPage
     }
 
     /// <summary>
-    /// Handler for the Clicked event from the OnGoToLastPageButtonClicked control.
+    /// Handler for the Clicked event from the OnGoToLastPageButton control.
     /// </summary>
     /// <param name="sender"></param>
     /// <param name="e"></param>
     private async void OnGoToLastPageButtonClicked(object sender, EventArgs e)
     {
         await _viewModel.GoToLastPage();
+    }
+
+    /// <summary>
+    /// Handler for the SelectedIndexChanged event from the PageLengthPicker control.
+    /// </summary>
+    /// <param name="sender"></param>
+    /// <param name="e"></param>
+    private async void OnPageLengthPickerSelectedIndexChanged(object sender, EventArgs e)
+    {
+        // get the newly selected PageLength value and update it in the ViewModel
+        if (PageLengthPicker is null)
+        {
+            return;
+        }
+        int PageLength = (int)PageLengthPicker.ItemsSource[_viewModel.Options.SelectedPageLengthIndex]!;
+        _viewModel.Options.PageLength = PageLength;
+        // refresh the Data Table to use a new PageSet based on the selected PageLength
+        await _viewModel.RefreshPages();
     }
 
     /// <summary>

--- a/LotCoMClient/Views/DataTableSelectorPage.xaml.cs
+++ b/LotCoMClient/Views/DataTableSelectorPage.xaml.cs
@@ -1,4 +1,5 @@
 using LotCoMClient.Models.Datasources;
+using LotCoMClient.Models.Services;
 
 namespace LotCoMClient.Views;
 
@@ -120,6 +121,20 @@ public partial class DataTableSelectorPage : ContentPage
             _viewModel.Options.SelectedSearchingFieldIndex = ListViewSearchingFieldPicker.SelectedIndex;
             _viewModel.SearchDataTable();
         });
+    }
+
+    /// <summary>
+    /// Handler for the Clicked event from the ListViewSearchingClearButton and ListViewSortingClearButton controls. 
+    /// </summary>
+    /// <param name="sender"></param>
+    /// <param name="e"></param>
+    private async void OnListViewFilterClearButtonClicked(object sender, EventArgs e)
+    {
+        // clear the Page's filtering Options, refresh the Base Pages, and reset the Page's CurrentPage
+        _viewModel.ClearFilterOptions();
+        await _viewModel.Table!.RefreshPages(-1, _viewModel.Options.PageLength);
+        await _viewModel.Table!.GoToBasePages();
+        _viewModel.CurrentPage = new NotifyTaskCompletion<Models.Datasources.Page>(_viewModel.Table.ActivePageSet.GetActivePage());
     }
 
     /// <summary>

--- a/LotCoMClient/Views/DataTableSelectorPage.xaml.cs
+++ b/LotCoMClient/Views/DataTableSelectorPage.xaml.cs
@@ -54,25 +54,11 @@ public partial class DataTableSelectorPage : ContentPage
     }
 
     /// <summary>
-    /// Creates a new DataTableSelectorPage.
-    /// </summary>
-    /// <param name="PageTitle">A string to apply as the Page's Title.</param>
-    public DataTableSelectorPage(string DataTablePath, string PageTitle, string Department, Type RecordType, bool IsProcessAssigned = true) 
-    {
-		// instantiate the ViewModel
-        _viewModel = new ViewModels.DataTableSelectorViewModel(DataTablePath, PageTitle, Department, RecordType, IsProcessAssigned);
-        BindingContext = _viewModel;
-
-        // create the page from XAML
-		InitializeComponent();
-    }
-
-    /// <summary>
     /// Handler for the Clicked event from the PageLeftFrameCollapseButton control.
     /// </summary>
     /// <param name="sender"></param>
     /// <param name="e"></param>
-    public async void OnPageLeftFrameCollapseButtonClicked(object sender, EventArgs e) 
+    private async void OnPageLeftFrameCollapseButtonClicked(object sender, EventArgs e) 
     {
         await Task.Delay(0);
         if (_viewModel.Options.IsLeftPanelShown) 
@@ -83,24 +69,7 @@ public partial class DataTableSelectorPage : ContentPage
         {
             _viewModel.Options.RaiseLeftPanel();
         }
-        PageLeftFrameCollapseButton.Rotation += 180;
-    }
-
-    /// <summary>
-    /// Handler for the SelectedIndexChanged event from the PageProcessPicker control.
-    /// </summary>
-    /// <param name="sender"></param>
-    /// <param name="e"></param>
-    private void OnPageProcessSelectionChanged(object sender, EventArgs e) 
-    {
-        // invoke the ViewModel method to update the UI
-        _viewModel.UpdatePageProcess(PageProcessPicker);
-        // update and collapse the Page's Left Frame Panel
-        _viewModel.Options.LeftPanelHeaderText = ((Process)PageProcessPicker.ItemsSource[_viewModel.Options.SelectedProcessIndex]!).FullName;
-        if (_viewModel.Options.IsLeftPanelShown) 
-        {
-            OnPageLeftFrameCollapseButtonClicked(PageLeftFrameCollapseButton, new EventArgs());
-        }
+        LeftPanelCollapseButton.Rotation += 180;
     }
 
     /// <summary>
@@ -108,7 +77,7 @@ public partial class DataTableSelectorPage : ContentPage
     /// </summary>
     /// <param name="sender"></param>
     /// <param name="e"></param>
-    public async void OnPageDataTableListViewPropertyChanged(object sender, EventArgs e) 
+    private async void OnPageDataTableListViewPropertyChanged(object sender, EventArgs e) 
     {
         // update BodyTableHeader property
         await ConfigureBodyHeader();
@@ -120,7 +89,7 @@ public partial class DataTableSelectorPage : ContentPage
     /// </summary>
     /// <param name="sender"></param>
     /// <param name="e"></param>
-    public async void OnSortParameterSelectedIndexChanged(object sender, EventArgs e) 
+    private async void OnSortParameterSelectedIndexChanged(object sender, EventArgs e) 
     {
         // update ViewModel sorting indexes
         _viewModel.Options.SelectedSortingFieldIndex = ListViewSortingFieldPicker.SelectedIndex;
@@ -134,7 +103,7 @@ public partial class DataTableSelectorPage : ContentPage
     /// </summary>
     /// <param name="sender"></param>
     /// <param name="e"></param>
-    public async void OnListViewSearchButtonPressed(object sender, EventArgs e) 
+    private async void OnListViewSearchButtonPressed(object sender, EventArgs e) 
     {
         await Task.Run(() => 
         {
@@ -143,5 +112,76 @@ public partial class DataTableSelectorPage : ContentPage
             _viewModel.Options.SelectedSearchingFieldIndex = ListViewSearchingFieldPicker.SelectedIndex;
             _viewModel.SearchDataTable();
         });
+    }
+
+    /// <summary>
+    /// Handler for the SelectedIndexChanged event from the PageProcessPicker control.
+    /// </summary>
+    /// <param name="sender"></param>
+    /// <param name="e"></param>
+    private void OnPageProcessSelectionChanged(object sender, EventArgs e) 
+    {
+        // invoke the ViewModel method to update the UI
+        _viewModel.UpdatePageProcess(ProcessPicker);
+        // update and collapse the Page's Left Frame Panel
+        _viewModel.Options.LeftPanelHeaderText = ((Process)ProcessPicker.ItemsSource[_viewModel.Options.SelectedProcessIndex]!).FullName;
+        if (_viewModel.Options.IsLeftPanelShown) 
+        {
+            OnPageLeftFrameCollapseButtonClicked(LeftPanelCollapseButton, new EventArgs());
+        }
+    }
+
+    /// <summary>
+    /// Handler for the Clicked event from the OnGoToFirstPageButtonClicked control.
+    /// </summary>
+    /// <param name="sender"></param>
+    /// <param name="e"></param>
+    private async void OnGoToFirstPageButtonClicked(object sender, EventArgs e)
+    {
+        await _viewModel.GoToFirstPage();
+    }
+
+    /// <summary>
+    /// Handler for the Clicked event from the OnGoToPreviousPageButtonClicked control.
+    /// </summary>
+    /// <param name="sender"></param>
+    /// <param name="e"></param>
+    private async void OnGoToPreviousPageButtonClicked(object sender, EventArgs e)
+    {
+        await _viewModel.GoToPreviousPage();
+    }
+
+    /// <summary>
+    /// Handler for the Clicked event from the OnGoToNextPageButtonClicked control.
+    /// </summary>
+    /// <param name="sender"></param>
+    /// <param name="e"></param>
+    private async void OnGoToNextPageButtonClicked(object sender, EventArgs e)
+    {
+        await _viewModel.GoToNextPage();
+    }
+
+    /// <summary>
+    /// Handler for the Clicked event from the OnGoToLastPageButtonClicked control.
+    /// </summary>
+    /// <param name="sender"></param>
+    /// <param name="e"></param>
+    private async void OnGoToLastPageButtonClicked(object sender, EventArgs e)
+    {
+        await _viewModel.GoToLastPage();
+    }
+
+    /// <summary>
+    /// Creates a new DataTableSelectorPage.
+    /// </summary>
+    /// <param name="PageTitle">A string to apply as the Page's Title.</param>
+    public DataTableSelectorPage(string DataTablePath, string PageTitle, string Department, Type RecordType, bool IsProcessAssigned = true) 
+    {
+		// instantiate the ViewModel
+        _viewModel = new ViewModels.DataTableSelectorViewModel(DataTablePath, PageTitle, Department, RecordType, IsProcessAssigned);
+        BindingContext = _viewModel;
+
+        // create the page from XAML
+		InitializeComponent();
     }
 }

--- a/LotCoMClient/Views/DataTableSelectorPage.xaml.cs
+++ b/LotCoMClient/Views/DataTableSelectorPage.xaml.cs
@@ -13,40 +13,40 @@ public partial class DataTableSelectorPage : ContentPage
 	private readonly ViewModels.DataTableSelectorViewModel _viewModel;
 
     /// <summary>
-    /// Asynchronously evaluates the state of the Data property and configures the Body Header accordingly.
-    /// If Data is loaded, shows the Navigation Panel. Else, shows "Loading Records...".
+    /// Asynchronously evaluates the state of the CurrentPage property and configures the Body Header accordingly.
+    /// If CurrentPage is loaded, shows the Navigation Panel. Else, shows "Loading Records...".
     /// </summary>
     private async Task ConfigureBodyHeader() 
     {
         await Task.Run(() => 
         {
-            // do not do any processing if Data is null (no-Process instantiation)
-            if (_viewModel.Data == null) 
+            // do not do any processing if there is no CurrentPage to show (no-Process instantiation)
+            if (_viewModel.CurrentPage is null) 
             {
                 return;
             }
-            // the Data property is set and is either loading or completed
-            if (_viewModel.Data!.IsCompleted && _viewModel.Data.Result != null) 
+            // the CurrentPage is set and is either loading or completed
+            if (_viewModel.CurrentPage!.IsCompleted && _viewModel.CurrentPage.Result != null) 
             {
-                // update the BodyTableHeader to show the item count and navigation
+                // CurrentPage is loaded; update the BodyTableHeader to show the item count and navigation
                 _viewModel.Options.SetBodyHeaderModeToNavigation();
             } 
             else 
             {
-                // the data is not loaded yet; default Body Table Header options
-                _viewModel.Options.SetBodyHeaderModeToLabel("Loading Records...");
+                // the CurrentPage is not loaded yet; default Body Table Header options
+                _viewModel.Options.SetBodyHeaderModeToLabel("Loading records...");
             }
         });
     }
 
     /// <summary>
-    /// Checks that the Table has DataRecords available. Updates the Data and Search fields based on that Data.
+    /// Checks that the Table has a CurrentPage available. Updates the Data and Search fields based on that Page's DataRecords.
     /// </summary>
     /// <returns></returns>
     private async Task ConfigurePageFields() 
     {
         // confirm that the Data property has completed its async task
-        if (_viewModel.Data == null || _viewModel.Data.IsNotCompleted) 
+        if (_viewModel.CurrentPage is null || _viewModel.CurrentPage.IsNotCompleted) 
         {
             return;
         }
@@ -122,14 +122,11 @@ public partial class DataTableSelectorPage : ContentPage
     /// <param name="e"></param>
     public async void OnSortParameterSelectedIndexChanged(object sender, EventArgs e) 
     {
-        await Task.Run(() => 
-        {
-            // update ViewModel sorting indexes
-            _viewModel.Options.SelectedSortingFieldIndex = ListViewSortingFieldPicker.SelectedIndex;
-            _viewModel.Options.SelectedSortingOrderIndex = ListViewSortingOrderPicker.SelectedIndex;
-            // invoke the ViewModel sort method
-            _viewModel.SortDataTable();
-        });
+        // update ViewModel sorting indexes
+        _viewModel.Options.SelectedSortingFieldIndex = ListViewSortingFieldPicker.SelectedIndex;
+        _viewModel.Options.SelectedSortingOrderIndex = ListViewSortingOrderPicker.SelectedIndex;
+        // invoke the ViewModel sort method
+        await _viewModel.SortPage();
     }
 
     /// <summary>

--- a/LotCoMClient/Views/DataTableSelectorPage.xaml.cs
+++ b/LotCoMClient/Views/DataTableSelectorPage.xaml.cs
@@ -1,5 +1,4 @@
 using LotCoMClient.Models.Datasources;
-using LotCoMClient.Models.Options;
 
 namespace LotCoMClient.Views;
 
@@ -76,24 +75,15 @@ public partial class DataTableSelectorPage : ContentPage
     public async void OnPageLeftFrameCollapseButtonClicked(object sender, EventArgs e) 
     {
         await Task.Delay(0);
-        // the Panel needs to collapse
         if (_viewModel.Options.IsLeftPanelShown) 
         {
-            // set the Left Panel properties in the Page Options
-            _viewModel.Options.IsLeftPanelShown = false;
-            _viewModel.Options.IsLeftPanelHidden = true;
-            _viewModel.Options.LeftPanelWidth = (int)DataTablePageOptions.LeftPanelWidths.Closed;
-            PageLeftFrameCollapseButton.Rotation += 180;
-        // the Panel needs to raise
+            _viewModel.Options.CollapseLeftPanel();
         } 
         else 
         {
-            // set the Left Panel properties in the Page Options
-            _viewModel.Options.IsLeftPanelShown = true;
-            _viewModel.Options.IsLeftPanelHidden = false;
-            _viewModel.Options.LeftPanelWidth = (int)DataTablePageOptions.LeftPanelWidths.Open;
-            PageLeftFrameCollapseButton.Rotation += 180;
+            _viewModel.Options.RaiseLeftPanel();
         }
+        PageLeftFrameCollapseButton.Rotation += 180;
     }
 
     /// <summary>

--- a/LotCoMClient/Views/DataTableSelectorPage.xaml.cs
+++ b/LotCoMClient/Views/DataTableSelectorPage.xaml.cs
@@ -1,3 +1,4 @@
+using System.Threading.Tasks;
 using LotCoMClient.Models.Datasources;
 using LotCoMClient.Models.Services;
 
@@ -159,9 +160,9 @@ public partial class DataTableSelectorPage : ContentPage
     /// </summary>
     /// <param name="sender"></param>
     /// <param name="e"></param>
-    private async void OnGoToFirstPageButtonClicked(object sender, EventArgs e)
+    private void OnGoToFirstPageButtonClicked(object sender, EventArgs e)
     {
-        await _viewModel.GoToFirstPage();
+        _viewModel.GoToFirstPage();
     }
 
     /// <summary>
@@ -169,9 +170,9 @@ public partial class DataTableSelectorPage : ContentPage
     /// </summary>
     /// <param name="sender"></param>
     /// <param name="e"></param>
-    private async void OnGoToPreviousPageButtonClicked(object sender, EventArgs e)
+    private void OnGoToPreviousPageButtonClicked(object sender, EventArgs e)
     {
-        await _viewModel.GoToPreviousPage();
+        _viewModel.GoToPreviousPage();
     }
 
     /// <summary>
@@ -179,9 +180,9 @@ public partial class DataTableSelectorPage : ContentPage
     /// </summary>
     /// <param name="sender"></param>
     /// <param name="e"></param>
-    private async void OnGoToNextPageButtonClicked(object sender, EventArgs e)
+    private void OnGoToNextPageButtonClicked(object sender, EventArgs e)
     {
-        await _viewModel.GoToNextPage();
+        _viewModel.GoToNextPage();
     }
 
     /// <summary>
@@ -189,9 +190,9 @@ public partial class DataTableSelectorPage : ContentPage
     /// </summary>
     /// <param name="sender"></param>
     /// <param name="e"></param>
-    private async void OnGoToLastPageButtonClicked(object sender, EventArgs e)
+    private void OnGoToLastPageButtonClicked(object sender, EventArgs e)
     {
-        await _viewModel.GoToLastPage();
+        _viewModel.GoToLastPage();
     }
 
     /// <summary>
@@ -199,7 +200,7 @@ public partial class DataTableSelectorPage : ContentPage
     /// </summary>
     /// <param name="sender"></param>
     /// <param name="e"></param>
-    private async void OnPageLengthPickerSelectedIndexChanged(object sender, EventArgs e)
+    private void OnPageLengthPickerSelectedIndexChanged(object sender, EventArgs e)
     {
         // get the newly selected PageLength value and update it in the ViewModel
         if (PageLengthPicker is null)
@@ -209,7 +210,7 @@ public partial class DataTableSelectorPage : ContentPage
         int PageLength = (int)PageLengthPicker.ItemsSource[_viewModel.Options.SelectedPageLengthIndex]!;
         _viewModel.Options.PageLength = PageLength;
         // refresh the Data Table to use a new PageSet based on the selected PageLength
-        await _viewModel.RefreshPages();
+        _viewModel.RefreshPages();
         _viewModel.ClearFilterOptions();
     }
 

--- a/LotCoMClient/Views/DataTableSelectorPage.xaml.cs
+++ b/LotCoMClient/Views/DataTableSelectorPage.xaml.cs
@@ -14,11 +14,6 @@ public partial class DataTableSelectorPage : ContentPage
 	private readonly ViewModels.DataTableSelectorViewModel _viewModel;
 
     /// <summary>
-    /// The ViewModel's Options property, exposed for easier access.
-    /// </summary>
-    private readonly DataTablePageOptions _options;
-
-    /// <summary>
     /// Asynchronously evaluates the state of the Data property and configures the Body Header accordingly.
     /// If Data is loaded, shows the Navigation Panel. Else, shows "Loading Records...".
     /// </summary>
@@ -35,12 +30,12 @@ public partial class DataTableSelectorPage : ContentPage
             if (_viewModel.Data!.IsCompleted && _viewModel.Data.Result != null) 
             {
                 // update the BodyTableHeader to show the item count and navigation
-                _options.SetBodyHeaderModeToNavigation();
+                _viewModel.Options.SetBodyHeaderModeToNavigation();
             } 
             else 
             {
                 // the data is not loaded yet; default Body Table Header options
-                _options.SetBodyHeaderModeToLabel("Loading Records...");
+                _viewModel.Options.SetBodyHeaderModeToLabel("Loading Records...");
             }
         });
     }
@@ -56,7 +51,7 @@ public partial class DataTableSelectorPage : ContentPage
         {
             return;
         }
-        await _options.ConfigurePageFields();
+        await _viewModel.Options.ConfigurePageFields();
     }
 
     /// <summary>
@@ -67,7 +62,6 @@ public partial class DataTableSelectorPage : ContentPage
     {
 		// instantiate the ViewModel
         _viewModel = new ViewModels.DataTableSelectorViewModel(DataTablePath, PageTitle, Department, RecordType, IsProcessAssigned);
-        _options = _viewModel.Options;
         BindingContext = _viewModel;
 
         // create the page from XAML
@@ -83,21 +77,21 @@ public partial class DataTableSelectorPage : ContentPage
     {
         await Task.Delay(0);
         // the Panel needs to collapse
-        if (_options.IsLeftPanelShown) 
+        if (_viewModel.Options.IsLeftPanelShown) 
         {
             // set the Left Panel properties in the Page Options
-            _options.IsLeftPanelShown = false;
-            _options.IsLeftPanelHidden = true;
-            _options.LeftPanelWidth = (int)DataTablePageOptions.LeftPanelWidths.Closed;
+            _viewModel.Options.IsLeftPanelShown = false;
+            _viewModel.Options.IsLeftPanelHidden = true;
+            _viewModel.Options.LeftPanelWidth = (int)DataTablePageOptions.LeftPanelWidths.Closed;
             PageLeftFrameCollapseButton.Rotation += 180;
         // the Panel needs to raise
         } 
         else 
         {
             // set the Left Panel properties in the Page Options
-            _options.IsLeftPanelShown = true;
-            _options.IsLeftPanelHidden = false;
-            _options.LeftPanelWidth = (int)DataTablePageOptions.LeftPanelWidths.Open;
+            _viewModel.Options.IsLeftPanelShown = true;
+            _viewModel.Options.IsLeftPanelHidden = false;
+            _viewModel.Options.LeftPanelWidth = (int)DataTablePageOptions.LeftPanelWidths.Open;
             PageLeftFrameCollapseButton.Rotation += 180;
         }
     }
@@ -112,13 +106,13 @@ public partial class DataTableSelectorPage : ContentPage
         // invoke the ViewModel method to update the UI
         _viewModel.UpdatePageProcess(PageProcessPicker);
         // update and collapse the Page's Left Frame Panel
-        _options.LeftPanelHeaderText = ((Process)PageProcessPicker.ItemsSource[_options.SelectedProcessIndex]!).FullName;
-        if (_options.IsLeftPanelShown) 
+        _viewModel.Options.LeftPanelHeaderText = ((Process)PageProcessPicker.ItemsSource[_viewModel.Options.SelectedProcessIndex]!).FullName;
+        if (_viewModel.Options.IsLeftPanelShown) 
         {
             OnPageLeftFrameCollapseButtonClicked(PageLeftFrameCollapseButton, new EventArgs());
         }
     }
-    
+
     /// <summary>
     /// Handler for the PropertyChanged event from the PageDataTableListView control.
     /// </summary>
@@ -141,8 +135,8 @@ public partial class DataTableSelectorPage : ContentPage
         await Task.Run(() => 
         {
             // update ViewModel sorting indexes
-            _options.SelectedSortingFieldIndex = ListViewSortingFieldPicker.SelectedIndex;
-            _options.SelectedSortingOrderIndex = ListViewSortingOrderPicker.SelectedIndex;
+            _viewModel.Options.SelectedSortingFieldIndex = ListViewSortingFieldPicker.SelectedIndex;
+            _viewModel.Options.SelectedSortingOrderIndex = ListViewSortingOrderPicker.SelectedIndex;
             // invoke the ViewModel sort method
             _viewModel.SortDataTable();
         });
@@ -158,8 +152,8 @@ public partial class DataTableSelectorPage : ContentPage
         await Task.Run(() => 
         {
             // invoke the ViewModel local sort method using the current search term
-            _options.SearchTerm = ListViewSearchingSearchBar.Text;
-            _options.SelectedSearchingFieldIndex = ListViewSearchingFieldPicker.SelectedIndex;
+            _viewModel.Options.SearchTerm = ListViewSearchingSearchBar.Text;
+            _viewModel.Options.SelectedSearchingFieldIndex = ListViewSearchingFieldPicker.SelectedIndex;
             _viewModel.SearchDataTable();
         });
     }

--- a/LotCoMClient/Views/DataTableSelectorPage.xaml.cs
+++ b/LotCoMClient/Views/DataTableSelectorPage.xaml.cs
@@ -46,57 +46,17 @@ public partial class DataTableSelectorPage : ContentPage
     }
 
     /// <summary>
-    /// Checks that the Table has DataRecords available. Updates the Data fields based on that Data.
+    /// Checks that the Table has DataRecords available. Updates the Data and Search fields based on that Data.
     /// </summary>
     /// <returns></returns>
-    private async Task ConfigureDataFields() 
+    private async Task ConfigurePageFields() 
     {
-        // perform the config logic on a new CPU thread
-        await Task.Run(() => 
+        // confirm that the Data property has completed its async task
+        if (_viewModel.Data == null || _viewModel.Data.IsNotCompleted) 
         {
-            // confirm that the Data property has completed its async task
-            if (_viewModel.Data == null || _viewModel.Data.IsNotCompleted) 
-            {
-                return;
-            }
-            List<string> Sortables = ["Part Number", "Part Name", "Quantity"];
-            // add the variably-required DataRecord fields (only if Data is loaded)
-            DataRecord SampleRecord;
-            if (_viewModel.Data.Result != null && _viewModel.Data.Result.Count > 0) 
-            {
-                SampleRecord = _viewModel.Data.Result[0];
-                if (SampleRecord.IncludesJBKNumber) 
-                {
-                    Sortables.Add("JBK Number");
-                }
-                if (SampleRecord.IncludesLotNumber) 
-                {
-                    Sortables.Add("Lot Number");
-                }
-                if (SampleRecord.IncludesDeburrJBKNumber) 
-                {
-                    Sortables.Add("Deburr JBK Number");
-                }
-                if (SampleRecord.IncludesDieNumber) 
-                {
-                    Sortables.Add("Die Number");
-                }
-                if (SampleRecord.IncludesModelNumber) 
-                {
-                    Sortables.Add("Model Number");
-                }
-                if (SampleRecord.IncludesHeatNumber) 
-                {
-                    Sortables.Add("Heat Number");
-                }
-            }
-            Sortables.AddRange(["Production Date", "Production Time", "Production Shift", "Operator ID"]);
-            // update the ViewModel DataFields and SearchableFields property
-            _options.DataFields = Sortables;
-            _options.SearchableFields = Sortables
-                .Prepend("All")
-                .ToList();
-        });
+            return;
+        }
+        await _options.ConfigurePageFields();
     }
 
     /// <summary>
@@ -168,7 +128,7 @@ public partial class DataTableSelectorPage : ContentPage
     {
         // update BodyTableHeader property
         await ConfigureBodyHeader();
-        await ConfigureDataFields();
+        await ConfigurePageFields();
     }
 
     /// <summary>

--- a/LotCoMClient/Views/DataTableSelectorPage.xaml.cs
+++ b/LotCoMClient/Views/DataTableSelectorPage.xaml.cs
@@ -92,6 +92,10 @@ public partial class DataTableSelectorPage : ContentPage
     private async void OnSortParameterSelectedIndexChanged(object sender, EventArgs e) 
     {
         // update ViewModel sorting indexes
+        if (ListViewSortingFieldPicker is null || ListViewSortingOrderPicker is null)
+        {
+            return;
+        }
         _viewModel.Options.SelectedSortingFieldIndex = ListViewSortingFieldPicker.SelectedIndex;
         _viewModel.Options.SelectedSortingOrderIndex = ListViewSortingOrderPicker.SelectedIndex;
         // invoke the ViewModel sort method
@@ -108,6 +112,10 @@ public partial class DataTableSelectorPage : ContentPage
         await Task.Run(() => 
         {
             // invoke the ViewModel local sort method using the current search term
+            if (ListViewSearchingFieldPicker is null)
+            {
+                return;
+            }
             _viewModel.Options.SearchTerm = ListViewSearchingSearchBar.Text;
             _viewModel.Options.SelectedSearchingFieldIndex = ListViewSearchingFieldPicker.SelectedIndex;
             _viewModel.SearchDataTable();
@@ -187,6 +195,7 @@ public partial class DataTableSelectorPage : ContentPage
         _viewModel.Options.PageLength = PageLength;
         // refresh the Data Table to use a new PageSet based on the selected PageLength
         await _viewModel.RefreshPages();
+        _viewModel.ClearFilterOptions();
     }
 
     /// <summary>

--- a/LotCoMClient/Views/DataTableSelectorPage.xaml.cs
+++ b/LotCoMClient/Views/DataTableSelectorPage.xaml.cs
@@ -19,15 +19,13 @@ public partial class DataTableSelectorPage : ContentPage
     private readonly DataTablePageOptions _options;
 
     /// <summary>
-    /// Asynchronously evaluates the state of the Data property and sets the BodyTableHeader property accordingly.
-    /// If Data is loaded, shows the Record count. Else, shows "Loading Records...".
+    /// Asynchronously evaluates the state of the Data property and configures the Body Header accordingly.
+    /// If Data is loaded, shows the Navigation Panel. Else, shows "Loading Records...".
     /// </summary>
-    private async Task ConfigureBodyTableHeader() 
+    private async Task ConfigureBodyHeader() 
     {
         await Task.Run(() => 
         {
-            // get the count of Data entries
-            int DataCount;
             // do not do any processing if Data is null (no-Process instantiation)
             if (_viewModel.Data == null) 
             {
@@ -36,21 +34,13 @@ public partial class DataTableSelectorPage : ContentPage
             // the Data property is set and is either loading or completed
             if (_viewModel.Data!.IsCompleted && _viewModel.Data.Result != null) 
             {
-                DataCount = _viewModel.Data.Result.Count;
-                // update the BodyTableHeader to show the item count
-                if (DataCount > 1) 
-                {
-                    _options.BodyTableHeaderText = $"Showing {DataCount} records";
-                } 
-                else 
-                {
-                    _options.BodyTableHeaderText = $"Showing {DataCount} records";
-                }
-            // the data is not loaded yet; default BodyTableHeader property
+                // update the BodyTableHeader to show the item count and navigation
+                _options.SetBodyHeaderModeToNavigation();
             } 
             else 
             {
-                _options.BodyTableHeaderText = "Loading records...";
+                // the data is not loaded yet; default Body Table Header options
+                _options.SetBodyHeaderModeToLabel("Loading Records...");
             }
         });
     }
@@ -135,38 +125,20 @@ public partial class DataTableSelectorPage : ContentPage
         // the Panel needs to collapse
         if (_options.IsLeftPanelShown) 
         {
-            // set the Left Panel properties in the ViewModel
+            // set the Left Panel properties in the Page Options
             _options.IsLeftPanelShown = false;
             _options.IsLeftPanelHidden = true;
-            // non-animated collapse
             _options.LeftPanelWidth = (int)DataTablePageOptions.LeftPanelWidths.Closed;
             PageLeftFrameCollapseButton.Rotation += 180;
-            // // 12 frame animation (250 -> 30 by increments of 10)
-            // while (_viewModel.LeftFrameWidth > 30) {
-            //     // animate the panel shrinking
-            //     _viewModel.LeftFrameWidth -= 10;
-            //     // animate the collapse button rotating
-            //     PageLeftFrameCollapseButton.Rotation += 15;
-            //     await Task.Delay(1);
-            // }
         // the Panel needs to raise
         } 
         else 
         {
-            // set the Left Panel properties in the ViewModel
+            // set the Left Panel properties in the Page Options
             _options.IsLeftPanelShown = true;
             _options.IsLeftPanelHidden = false;
-            // non-animated raise
             _options.LeftPanelWidth = (int)DataTablePageOptions.LeftPanelWidths.Open;
             PageLeftFrameCollapseButton.Rotation += 180;
-            // // 12 frame animation (30 -> 250 by increments of 10)
-            // while (_viewModel.LeftFrameWidth < 250) {
-            //     // animate the panel raising
-            //     _viewModel.LeftFrameWidth += 10;
-            //     // animate the collapse button rotating
-            //     PageLeftFrameCollapseButton.Rotation += 15;
-            //     await Task.Delay(1);
-            // }
         }
     }
 
@@ -195,7 +167,7 @@ public partial class DataTableSelectorPage : ContentPage
     public async void OnPageDataTableListViewPropertyChanged(object sender, EventArgs e) 
     {
         // update BodyTableHeader property
-        await ConfigureBodyTableHeader();
+        await ConfigureBodyHeader();
         await ConfigureDataFields();
     }
 


### PR DESCRIPTION
# feature/37

## Addressed Feature Request
Resolves #37 

## Summary

Data Table Pagination and Page Navigation creates a much more responsive UI experience as the user requests smaller amounts of Data at once. Additionally, Data is only objectified in runtime immediately before it is displayed. Un-requested Data remains in raw form until requested.

## Rationale

This feature addresses infinitely-growing load times as more Data is loaded into the LotCom database. 

## Changes

#### `DataRecord.cs`:
- Add `ProductionDate` & `ProductionTime` properties.
  - Allows `ScanRecords` to capture both the Scan Timestamp and the Scanned Label's Production Timestamp.
- Add `Includes` flags and `ProductionTimestamp` properties to further improve how `DataRecords` (especially `ScanRecords`) are rendered by `DataTablePages`.
- Refactor the `.ToCSV()` method that address discrepancies between the output and the Database Schemas.

#### `PrintRecord.cs` & `ScanRecord.cs`:
- Refactor `ctor` to integrate with new `DataRecord` properties.

#### `RecordParser.cs`:
- Refactor the `.ParseIPAddressAsync()` method to use the correct index of the raw Data Line.
- Refactor the `.ParseScanRecordFromCSVAsync()` method to correctly parse `ScanRecord` objects.
  - Includes parsing Production Date and Time.

#### `DataTable.cs`:
- Add `LastReadLines` and `SearchResultLines` properties.
  - Allows the class to store raw Data for bulk Data processes. Reduces processing time and overhead for `Searching` and `Loading` processes, as only the necessary Data is fully converted to `DataRecord` objects.
- Add `BasePages` and `SearchPages` properties.
  - Allows the class to store two different PageSet objects that can be toggled between.
  - The `BasePages` `PageSet` controls the read Data Pages while the `SearchPages` `PageSet` controls the resulting Pages of a `Search`.
- Add `ActivePageSet` property.
  - Allows the class to ambiguously refer to the current active `PageSet` while toggling between `BasePages` and `SearchPages`.
- Add synchronous version of the `.ParseLinesAsync()` method that can be called on instantiation.
- Add the `.ReadLines()` and `.ReadLinesAsync()` methods that load the raw Data from the Database's Data Table into runtime without formatting or conversions.
- Add the `.GoToFirstPage()`, `.GoToPreviousPage()`, `.GoToNextPage()`, and `.GoToLastPage()` Page Navigation methods.
- Add the `.GoToBasePages()` and `.GoToSearchPages()` methods to toggle between `PageSets`.
- Add the `.RefreshPages()` method to refresh raw Data and `PageSets` from the loaded Data.
- Add the `.RequestPage()` method to get a `Page` from the active `PageSet`.
- Refactor the `.SearchAllFieldsAsync()` method to utilize the `.ReadLinesAsync()` method and the `LastReadLines` and `SearchResultLines` properties.
  - No longer converts the raw Data into `DataRecord` objects.
- Refactor the `.SearchSingleFieldAsync()` method to leverage the efficiency of `.SearchAllFieldsAsync()`.
  - Only performs the costly conversion to `DataRecords` on matches from `.SearchAllFieldsAsync()` and before searching in the specific property. 
  - Much more efficient than the previous algorithm where ALL raw Data was converted to `DataRecords`.
- Refactor the `.SearchAsync()` method to utilize the `SearchPages` property.
- Remove `RecordsState` property as it is deprecated by the Pagination features.
- Remove the `.ReadAsync()`, `.RequestRecords()`, `.ReadRecordsAsync()`, `.RequestSort()`, `.SaveRecordsAsync()` methods as they are deprecated by the Pagination features.

#### `DataTablePageOptions.cs`:
- Add `OptionDefaults` nested class that provides default values for most Options properties.
- Add `PageNumber`, `SelectedPageLengthIndex`, and `PageLength` options.
  - Allows control over values shown in `VisualElements` of the Page Navigation Panel.
- Add the `.SetBodyHeaderModeToLabel()` and `SetBodyHeaderModeToNavigation()` methods.
  - Toggles the visibility of Body Header `VisualElements` to swap between showing a basic `Label` and the Page Navigation Panel in the `DataTablePage`'s Body Header area.
- Add the `.ConfigurePageFields()` method to set the `DataFields` and `SearchFields` options.
- Add the `.RaiseLeftPanel()` and `.CollapseLeftPanel()` methods to control the Left Panel's visibility.
- Refactor many properties to use the `ObservableProperty` attribute.

#### `DataTableViewModel.cs` & `DataTableSelectorViewModel.cs`:
- Add `BasePage` and `CurrentPage` properties.
  - `BasePage` holds the unmodified `Page` assigned to the `DataTablePage` while `CurrentPage` holds a copy that can be modified.
- Add `PageNumberContext` property.
  - A string providing information on the current `Page` in context of the full `PageSet`.
- Add the `.SortCurrentPage()` method and the `public` accessor method `.SortPage()`. 
  - Sorts the `DataRecords` in `CurrentPage` and updates the `Page` to display the results.
- Add the `.ClearFilterOptions()` method that resets both Sort and Search Options to their defaults.
- Add the `.SetNewPage()` method that creates a new `NotifyTaskCompletion` service object and sets `CurrentPage` to that new object.
- Add the `.GoToFirstPage()`, `.GoToPreviousPage()`, `.GoToNextPage()`, and `.GoToLastPage()` methods that power the `DataTablePage`'s Page Navigation Buttons.
- Add the `.RefreshPages()` method. 
  - Resets the `BasePage` and `CurrentPage` properties to the raw Data in `Table`.
- Refactor the `.SearchDataTable()` method to integrate with the refactored `DataTable.SearchAsync()` method.
- Refactor `.ctor` to set and configure several additional `Options` properties.
- Remove the `Data` property as it is deprecated by the Pagination features.
- Remove the `.SortDataTable()` method as sorting entire `DataTables` is no longer supported.

#### `DataTablePage.xaml.cs` & `DataTableSelectorPage.xaml.cs`
- Add `Event Handlers` for the `Clicked` event from `ListViewSortingClearButton` and `ListViewSearchingClearButton`.
- Add `Event Handlers` for the `Clicked` event from the Page Navigation Panel `Button` `VisualElements`.
- Add `Event Handler` for the `SelectedIndexChanged` event from the `PageLengthPicker` `VisualElement`.
- Refactor all `Event Handlers` protection levels to `private`.
- Refactor references to integrate with `DataTableViewModel` refactors.
- Refactor references to integrate with `DataTablePage` name changes.
- Refactor several methods to invoke new members of `DataTablePageOptions`.
- Remove the `Options` property as its exposure functionality violates `MVVM` paradigms.

#### `DataTablePage.xaml` & `DataTableSelectorPage.xaml`:
- Add `ListViewSortingClearButton` and `ListViewSearchingClearButton` `Buttons`.
  - Clear and reset the filtering `Options` and refresh the `CurrentPage` property.
- Add Page Navigation Panel `Grid` and `VisualElements`.
- Refactor several Bindings to integrate with `DataTableViewModel` refactors.
- Refactor several `VisualElement` names to better match their purposes.
- Refactor `ListView` `DataTemplate` to dynamically change and display the necessary `DataRecord` properties for both `PrintRecord` and `ScanRecord` objects.

## New classes:

#### `Page.cs`:
- Allows the grouping of raw Data into a Page that can be displayed and manipulated.
  - `RecordType` property controls the `Type` of `DataRecord` that can be contained by the `Page`.
  - `MaxLength` property controls the number of `DataRecords` that can be held by the `Page`.
  - `Count` property provides the current number of `DataRecords` contained by the `Page`.
  - `IsParsed` property tracks whether the `Page` has been converted from raw to `DataRecords`.
  - `Lines` property contains the raw Data contained by the `Page`
  - `DataRecords` property contains the `DataRecord` objects contained by the `Page`.
  - `ParseRecordAsync()` method attempts to convert a raw Data Line into a `DataRecord` of `Type` #### `RecordType`.
  - `GenerateDataRecords()` method converts all of the `Page`'s raw Data into `DataRecords`.

#### `PageSet.cs`:
- Allows the grouping of `Page` objects and manipulation of said group.
  - `MaxCount` property controls the number of `Page` objects allowed in the `PageSet`.
  - `IsLimitedSize` property returns whether the `PageSet` has a `Page` limit.
  - `RecordType` property controls the `Type` of `DataRecord` that can be contained by the `Page` objects within the `PageSet`.
  - `ActivePage` property returns the currently active `Page` in the `PageSet`.
  - `HasPrevious` property returns whether the `PageSet` has a `Page` before the current one.
  - `HasNext` property returns whether the `PageSet` has a `Page` after the current one.
  - `Pages` property holds the List of `Page` objects contained by the `PageSet`.
  - `ActivePageIndex` property holds the index of the active `Page` in `Pages`.
  - `PageLength` property controls the `MaxLength` property of the `Pages` contained by the `PageSet`.
  - `PageCount` property returns the current number of `Pages` contained by the `PageSet`.
  - `EntryCount` property returns the current number of raw Data entries in the entire `PageSet`.
  - `HasSpace` property returns whether the `PageSet` has room for more `Pages` or not.
  - `Paginate()` method converts a passed List of raw Data lines into a List of `Pages`.
  - `GenerateActivePage()` method converts the raw Data in the currently active `Page` to `DataRecords`.
  - `GetActivePage()` method generates and returns the currently active `Page` in the `PageSet`.
  - `SetActivePage()` method changes the currently active `Page` in the `PageSet`.
  - `GoToFirstPage()`, `GoToPreviousPage()`, `GoToLastPage()`, `GoToNextPage()` methods change the currently active `Page` based on `PageCount` and the currently active `Page`'s position.
  - `GetTotalEntryCount()` method calculates the `EntryCount` property.

## Impact

Previously, `Print` and `Scan` `DataTablePages` were taking up to a minute to load all 600+ current `DataRecords`. Now, with the initial load size capped at 25 `DataRecords`, `DataTablePages` display `DataRecords` within 3 seconds.

Additionally, implementing a user-friendly Page Navigation UI and limiting the number of Records shown at a time improves the clarity of the application. After a short amount of time, Record counts will reach into the thousands and viewing all of them at once would be very unwieldy.

## Checklist

- [x] Code follows the project's coding standards

- [x] The documentation has been updated to reflect the new feature

## Additional Notes

Signed-off-by: Mason Ritchason <masonritchason@gmail.com>