### PR TITLE
bug/41

### DIFF
--- a/LotCoMClient/Models/Datasources/DataRecord.cs
+++ b/LotCoMClient/Models/Datasources/DataRecord.cs
@@ -110,7 +110,7 @@ public partial class DataRecord : ObservableObject
         IncludesLotNumber = Requirements.Contains("LotNumber");
         IncludesDeburrJBKNumber = Requirements.Contains("DeburrJBKNumber");
         IncludesDieNumber = Requirements.Contains("DieNumber");
-        IncludesDieNumber = Requirements.Contains("ModelNumber");
+        IncludesModelNumber = Requirements.Contains("ModelNumber");
         IncludesHeatNumber = Requirements.Contains("HeatNumber");
         IncludesScanAddress = ScanAddress is not null;
         IncludesProductionDate = ProductionDate is not null;


### PR DESCRIPTION
# bug/41

## Addressed Bug Report
Resolves #41 

## Summary

The bug reported in #41 is related to an issue rendering the Die # field on `DataTablePage` `ListView` Templates that should have the field included.

## Root Cause(s)/Faults

The root cause of this bug was a mis-assignment of the `IncludesDieNumber` and `IncludesModelNumber` properties in `DataRecord.cs`. The `IncludesDieNumber` property was assigned the desired value but then immediately and mistakenly assigned the value of the conditions for the `IncludesModelNumber` property.

## Rationale

The Die # is a necessary data field that is very important for problem range identification and lot tracing. Missing Die # fields is unacceptable.

## Changes

#### `DataRecord.cs`:
- Fixed mis-assignment of `IncludesDieNumber` property.

## Impact

The Die # field is now shown on all `DataTablePage` `ListViews` that it is required on.

## Checklist

- [x] Code follows the project's coding standards

- [x] The solution thoroughly and effectively addresses the root cause mentioned above

- [x] The documentation has been updated to reflect the new feature

## Additional Notes

Signed-off-by: Mason Ritchason <masonritchason@gmail.com>